### PR TITLE
Switch communication layer from SW to Atomics

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -7,6 +7,9 @@ const config: PlaywrightTestConfig = {
       width: 520,
       height: 600,
     },
+    launchOptions: {
+      args: ['--enable-features=SharedArrayBuffer'],
+    },
     contextOptions: {
       recordVideo: {
         dir: 'tests/videos/',

--- a/src/lib/atomics/sync-create-messenger-atomics.ts
+++ b/src/lib/atomics/sync-create-messenger-atomics.ts
@@ -1,8 +1,34 @@
-import type { Messenger } from '../types';
+import type { Messenger, PartytownWebWorker, MainWindow, MessageFromWorkerToSandbox, MainAccessRequest } from '../types';
 
-const createMessengerAtomics: Messenger = async (sandboxWindow, _receiveMessage) => {
-  console.log('ATOMICS ⚛️', sandboxWindow.location.href);
-  return true;
+import { WorkerMessageType } from '../types';
+import { onMessageFromWebWorker } from '../sandbox/on-messenge-from-worker';
+
+const createMessengerAtomics: Messenger = async (sandboxWindow, receiveMessage) => {
+  if (!('SharedArrayBuffer' in sandboxWindow)) {
+    return null;
+  }
+
+  return (
+    worker: PartytownWebWorker,
+    mainWindow: MainWindow,
+    msg: MessageFromWorkerToSandbox
+  ) => {
+    const msgType = msg[0];
+    if (msgType === WorkerMessageType.ForwardWorkerAccessRequest) {
+      const accessReq = msg[1] as MainAccessRequest;
+      receiveMessage(accessReq, (accessRsp) => {
+        const sharedData = new Int32Array(accessReq.$sharedDataBuffer$!);
+        const stringifiedData = JSON.stringify(accessRsp);
+        const stringifiedDataLength = stringifiedData.length;
+        for (let i = 0; i < stringifiedDataLength; i++) {
+          sharedData[i] = stringifiedData.charCodeAt(i);
+        }
+        Atomics.notify(sharedData, 0);
+      });
+    } else {
+      onMessageFromWebWorker(worker, mainWindow, msg);
+    }
+  };
 };
 
 export default createMessengerAtomics;

--- a/src/lib/atomics/sync-send-message-to-main-atomics.ts
+++ b/src/lib/atomics/sync-send-message-to-main-atomics.ts
@@ -1,14 +1,30 @@
 import type { MainAccessRequest, MainAccessResponse, WebWorkerContext } from '../types';
 
+import { WorkerMessageType } from '../types';
+
 const syncSendMessageToMainAtomics = (
   webWorkerCtx: WebWorkerContext,
   accessReq: MainAccessRequest
 ): MainAccessResponse => {
-  const accessRsp: MainAccessResponse = {
-    $msgId$: accessReq.$msgId$,
-    $error$: `Atomics not implemented (yet)`,
-  };
-  return accessRsp;
+  const sharedDataBuffer = new SharedArrayBuffer(1024 * 1024);
+  const sharedData = new Int32Array(sharedDataBuffer);
+
+  accessReq.$sharedDataBuffer$ = sharedDataBuffer;
+  webWorkerCtx.$postMessage$([WorkerMessageType.ForwardWorkerAccessRequest, accessReq]);
+
+  Atomics.wait(sharedData, 0, Atomics.load(sharedData, 0));
+
+  let accessRespStr = '';
+  let dataIndex = 0;
+  let charCode;
+
+  while (charCode = sharedData[dataIndex++]) {
+    accessRespStr += String.fromCharCode(charCode);
+  }
+
+  accessReq.$sharedDataBuffer$ = undefined;
+
+  return JSON.parse(accessRespStr) as MainAccessResponse;
 };
 
 export default syncSendMessageToMainAtomics;

--- a/src/lib/main/loader.ts
+++ b/src/lib/main/loader.ts
@@ -54,7 +54,7 @@ export function loader(
         clearTimeout(timeout);
       });
 
-      if (win.crossOriginIsolated) {
+      if ('SharedArrayBuffer' in win) {
         // atomics support
         ready('atomics');
       } else if ('serviceWorker' in nav) {

--- a/src/lib/sandbox/init-sandbox.ts
+++ b/src/lib/sandbox/init-sandbox.ts
@@ -7,7 +7,6 @@ import type {
   MessengerRequestCallback,
   PartytownWebWorker,
 } from '../types';
-import { onMessageFromWebWorker } from './on-messenge-from-worker';
 import { registerWindow } from './main-register-window';
 import syncCreateMessenger from '@sync-create-messenger';
 import WebWorkerBlob from '@web-worker-blob';
@@ -21,9 +20,9 @@ export const initSandbox = async (sandboxWindow: any) => {
   const receiveMessage: MessengerRequestCallback = (accessReq, responseCallback) =>
     mainAccessHandler(worker, accessReq).then(responseCallback);
 
-  const success = await syncCreateMessenger(sandboxWindow, receiveMessage);
+  const onMessageHandler = await syncCreateMessenger(sandboxWindow, receiveMessage);
 
-  if (success) {
+  if (onMessageHandler) {
     worker = new Worker(
       debug
         ? WebWorkerUrl
@@ -36,7 +35,7 @@ export const initSandbox = async (sandboxWindow: any) => {
     );
 
     worker.onmessage = (ev: MessageEvent<MessageFromWorkerToSandbox>) =>
-      onMessageFromWebWorker(worker, mainWindow, ev.data);
+      onMessageHandler(worker, mainWindow, ev.data);
 
     if (debug) {
       logMain(`Created web worker`);

--- a/src/lib/sandbox/on-messenge-from-worker.ts
+++ b/src/lib/sandbox/on-messenge-from-worker.ts
@@ -3,6 +3,7 @@ import {
   MainWindow,
   MessageFromWorkerToSandbox,
   PartytownWebWorker,
+  WinId,
   WorkerMessageType,
 } from '../types';
 import { randomId } from '../utils';
@@ -28,7 +29,8 @@ export const onMessageFromWebWorker = (
     // web worker has finished initializing and ready to run scripts
     registerWindow(worker, randomId(), mainWindow, 1);
   } else {
-    const winCtx = winCtxs[msg[1]]!;
+    const winId = msg[1] as WinId;
+    const winCtx = winCtxs[winId]!;
     if (winCtx) {
       if (msgType === WorkerMessageType.InitializeNextScript) {
         // web worker has been initialized with the main data

--- a/src/lib/service-worker/sync-create-messenger-sw.ts
+++ b/src/lib/service-worker/sync-create-messenger-sw.ts
@@ -1,5 +1,7 @@
 import type { MainAccessRequest, Messenger } from '../types';
 
+import { onMessageFromWebWorker } from '../sandbox/on-messenge-from-worker';
+
 const createMessengerServiceWorker: Messenger = async (sandboxWindow, receiveMessage) => {
   const swContainer = sandboxWindow.navigator.serviceWorker;
   const swRegistration = await swContainer.getRegistration();
@@ -12,7 +14,7 @@ const createMessengerServiceWorker: Messenger = async (sandboxWindow, receiveMes
 
   swContainer.addEventListener('message', receiveMessageFromWorker);
 
-  return !!swRegistration;
+  return !!swRegistration ? onMessageFromWebWorker : null;
 };
 
 export default createMessengerServiceWorker;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,7 +7,7 @@ export type CreateWorker = (workerName: string) => Worker;
 export type Messenger = (
   sandboxWindow: Window,
   receiveMessage: MessengerRequestCallback
-) => Promise<boolean>;
+) => Promise<MessengerHandler | null>;
 
 export type MessengerRequestCallback = (
   accessReq: MainAccessRequest,
@@ -16,13 +16,20 @@ export type MessengerRequestCallback = (
 
 export type MessengerResponseCallback = (accessRsp: MainAccessResponse) => void;
 
+export type MessengerHandler = (
+  worker: PartytownWebWorker,
+  mainWindow: MainWindow,
+  msg: MessageFromWorkerToSandbox
+) => void;
+
 export type WinId = number;
 
 export type MessageFromWorkerToSandbox =
   | [WorkerMessageType.MainDataRequestFromWorker]
   | [WorkerMessageType.InitializedWebWorker]
   | [WorkerMessageType.InitializedEnvironmentScript, WinId, number, string]
-  | [WorkerMessageType.InitializeNextScript, WinId];
+  | [WorkerMessageType.InitializeNextScript, WinId]
+  | [WorkerMessageType.ForwardWorkerAccessRequest, MainAccessRequest];
 
 export type MessageFromSandboxToWorker =
   | [WorkerMessageType.MainDataResponseToWorker, InitWebWorkerData]
@@ -42,6 +49,7 @@ export const enum WorkerMessageType {
   InitializeNextScript,
   RefHandlerCallback,
   ForwardMainTrigger,
+  ForwardWorkerAccessRequest,
 }
 
 export interface ForwardMainTriggerData {
@@ -173,6 +181,7 @@ export interface InitializeScriptData {
 export interface MainAccessRequest {
   $msgId$: number;
   $tasks$: MainAccessTask[];
+  $sharedDataBuffer$?: SharedArrayBuffer;
 }
 
 export interface MainAccessTask {


### PR DESCRIPTION
Hey!

First of all, I wanted to thank everybody involved in this project! It's been a tough year for me and I haven't been so excited for some after-hours hacking for a long time now.

As we discussed on Twitter, I spent some time exploring potential usage of Atomics as a synchronous communication layer between workers and the main thread. The current status is:

- All tests pass except the one for iframes, because they use separate XHR logic that I need to replace.
- Main piece of communication revolves around worker `postMessage`ing window with the request about the data it needs and then blocks itself on `Atomics.wait` until shared memory array is populated by the main thread.
- For now I'm using one huge memory buffer in hopes that it doesn't overflow, so the next step would be to use a smaller one + some kind of queue with back-and-forth resuming of partitioned data.
- Because ServiceWorker is no longer there, I think there has to be some stub added that would intercept `fetch` and `XMLHttpRequest` requests, but I haven't checked that yet.
- Since Spectre, using `SharedArrayBuffer` requires[ additional security](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer#security_requirements) headers which I'm suspecting may be more troublesome than setting up a ServiceWorker for some people.

It would be great to hear your feedback and ideas for potential improvements as the whole code is still quite new to me 😄 