### PR TITLE
suppressHydrationWarning

### DIFF
--- a/src/react/script.tsx
+++ b/src/react/script.tsx
@@ -48,5 +48,5 @@ export const PartytownScript = ({ id, innerHTML, type }: PartytownScriptProps): 
   if (type !== SCRIPT_TYPE) {
     jsxInnerHTML = `document.currentScript.dataset.ptScript=${JSON.stringify(id)};` + jsxInnerHTML;
   }
-  return <script dangerouslySetInnerHTML={{ __html: jsxInnerHTML }} type={type} />;
+  return <script suppressHydrationWarning dangerouslySetInnerHTML={{ __html: jsxInnerHTML }} type={type} />;
 };


### PR DESCRIPTION
This script is being placed in the head of my application it adds the `data-pt-script` attribute to the script tag *BEFORE* React has a chance to hydrate. Because the attribute has been added before react has had a chance to hydrate, React reports a warning to the console `Warning: Extra attributes from the server: data-pt-script`. 

Adding `suppressHydrationWarning` to the script tag will cause React to ignore that warning.