### PR TITLE
chore: fix typo in the module path

### DIFF
--- a/scripts/build-react.ts
+++ b/scripts/build-react.ts
@@ -17,7 +17,7 @@ export function buildReact(opts: BuildOptions): RollupOptions {
     ],
     external: ['react'],
     plugins: [
-      submodulePath('@builder.io/partytown/intergration', '../integration/index'),
+      submodulePath('@builder.io/partytown/integration', '../integration/index'),
       submodulePackageJson(
         '@builder.io/partytown/react',
         opts.srcReactDir,

--- a/src/lib/web-worker/init-web-worker.ts
+++ b/src/lib/web-worker/init-web-worker.ts
@@ -3,7 +3,7 @@ import { defineWorkerInterface, patchPrototypes } from './worker-define-construc
 import { logWorker } from '../log';
 import type { InitWebWorkerData } from '../types';
 import { Node } from './worker-node';
-import type { PartytownConfig } from '@builder.io/partytown/intergration';
+import type { PartytownConfig } from '@builder.io/partytown/integration';
 import { Performance } from './worker-performance';
 import { webWorkerCtx, webWorkerlocalStorage, webWorkerSessionStorage } from './worker-constants';
 import { Window } from './worker-window';

--- a/src/react/forward.tsx
+++ b/src/react/forward.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { appendForwardConfig } from '@builder.io/partytown/intergration';
+import { appendForwardConfig } from '@builder.io/partytown/integration';
 import { PartytownScript } from './script';
 import type { PartytownForwardProperty } from '../lib/types';
 

--- a/src/react/integration/facebook-pixel.tsx
+++ b/src/react/integration/facebook-pixel.tsx
@@ -3,7 +3,7 @@ import {
   facebookPixel,
   facebookPixelForward,
   SCRIPT_TYPE,
-} from '@builder.io/partytown/intergration';
+} from '@builder.io/partytown/integration';
 import { PartytownScript } from '../script';
 import { PartytownForward } from '../forward';
 

--- a/src/react/integration/google-tag-manager.tsx
+++ b/src/react/integration/google-tag-manager.tsx
@@ -3,7 +3,7 @@ import {
   googleTagManager,
   googleTagManagerForward,
   SCRIPT_TYPE,
-} from '@builder.io/partytown/intergration';
+} from '@builder.io/partytown/integration';
 import { PartytownScript } from '../script';
 import { PartytownForward } from '../forward';
 

--- a/src/react/library.tsx
+++ b/src/react/library.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { PartytownConfig } from '../lib/types';
-import { partytownSnippet } from '@builder.io/partytown/intergration';
+import { partytownSnippet } from '@builder.io/partytown/integration';
 import { PartytownScript } from './script';
 
 /**

--- a/src/react/script.tsx
+++ b/src/react/script.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { SCRIPT_TYPE } from '@builder.io/partytown/intergration';
+import { SCRIPT_TYPE } from '@builder.io/partytown/integration';
 
 export interface PartytownScriptProps {
   /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
     "jsx": "react",
     "baseUrl": ".",
     "paths": {
-      "@builder.io/partytown/intergration": ["src/integration/index.ts"],
+      "@builder.io/partytown/integration": ["src/integration/index.ts"],
       "react": ["node_modules/react"]
     }
   },


### PR DESCRIPTION
This PR fixes the typos present in `tsconfig.json` and other files which import from `integration` directory.