### PR TITLE
fix: polyfill __dirname in esm

### DIFF
--- a/src/utils/copy-lib-files.ts
+++ b/src/utils/copy-lib-files.ts
@@ -1,11 +1,14 @@
 import fs from 'fs';
-import { isAbsolute, resolve } from 'path';
+import { dirname, isAbsolute, resolve } from 'path';
+import { fileURLToPath } from 'url';
 import { promisify } from 'util';
 
 const copyFile = promisify(fs.copyFile);
 const mkdir = promisify(fs.mkdir);
 const readdir = promisify(fs.readdir);
 const stat = promisify(fs.stat);
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 /**
  * Absolute path to the Partytown lib directory within the


### PR DESCRIPTION
Otherwise when `utils/index.mjs` is imported we get the following error:

```
 ERROR  __dirname is not defined

  at libDirPath (node_modules/@builder.io/partytown/utils/index.mjs:16:20)
```