### PR TITLE
fix: prop deletion broke react snippet

### DIFF
--- a/src/integration/snippet.ts
+++ b/src/integration/snippet.ts
@@ -1,11 +1,9 @@
 import type { PartytownConfig } from '../lib/types';
 
 export const createSnippet = (config: PartytownConfig, snippetCode: string) => {
-  config = config || {};
-  const forward = config.forward || [];
-  delete config.forward;
+  const { forward = [], ...filteredConfig } = config || {};
 
-  const configStr = JSON.stringify(config, (k, v) => {
+  const configStr = JSON.stringify(filteredConfig, (k, v) => {
     if (typeof v === 'function') {
       v = String(v);
       if (v.startsWith(k + '(')) {
@@ -17,7 +15,7 @@ export const createSnippet = (config: PartytownConfig, snippetCode: string) => {
 
   return [
     `!(function(w,p,f,c){`,
-    Object.keys(config).length > 0
+    Object.keys(filteredConfig).length > 0
       ? `c=w[p]=Object.assign(w[p]||{},${configStr});`
       : `c=w[p]=w[p]||{};`,
     `c[f]=(c[f]||[])`,


### PR DESCRIPTION
This PR fixes the `Partytown` react component. The component uses the `partytownSnippet` function, which uses the props of the component to call `createSnippet`.

The problem here is that the `createSnippet` deletes a property from the props object, which is [immutable](https://stackoverflow.com/questions/47471131/why-are-react-props-immutable). This error was introduced at version 3.0.0.

This PR fixes the issue by deconstructing the prop without mutating it. This didn't fail on version 2.4 because the props were being spread in another object ([here](https://github.com/BuilderIO/partytown/blob/1cdf59a59ef9d39587ac7e1bec30091c189814ac/src/react/library.tsx#L22)), which allowed the properties to be deleted.