### PR TITLE
Return orignal `url` if reverse-proxy is not needed in `resolveUrl()`

### DIFF
--- a/tests/integrations/gtm/index.html
+++ b/tests/integrations/gtm/index.html
@@ -18,6 +18,8 @@
             proxyUrl.searchParams.append('url', url);
             return proxyUrl;
           }
+          
+          return url;
         },
         forward: ['dataLayer.push'],
         logCalls: true,


### PR DESCRIPTION
I assume that if the `url` need not to be reverse-proxied, the original `url` needs to be returned as shown in https://partytown.builder.io/proxying-requests