### PR TITLE
docs: Add "Serving Resources Locally" section

### DIFF
--- a/docs/proxying-requests.md
+++ b/docs/proxying-requests.md
@@ -52,3 +52,60 @@ Below are a few examples of [reverse proxies](https://en.wikipedia.org/wiki/Reve
 - [Netlify: Proxy to another service](https://docs.netlify.com/routing/redirects/rewrites-proxies/#proxy-to-another-service)
 - [NGINX](https://docs.nginx.com/nginx/admin-guide/web-server/reverse-proxy/)
 - [Vercel: Rewrites](https://vercel.com/docs/cli#project-configuration/rewrites)
+
+## Serving Resources Locally
+
+Another option to work around the `Access-Control-Allow-Origin` issue _without_ using a proxy is to serve your third-party JavaScript and other resources locally.
+
+So instead of inserting something like this on your page for [Google Analytics](https://developers.google.com/analytics/devguides/collection/analyticsjs):
+
+```html
+<!-- Google Analytics -->
+<script>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+
+ga('create', 'UA-XXXXX-Y', 'auto');
+ga('send', 'pageview');
+</script>
+<!-- End Google Analytics -->
+```
+
+You instead download the `analytics.js` JavaScript resource, and serve it locally from your domain like this:
+
+```html
+<!-- Google Analytics -->
+<script>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://example.com/analytics.js','ga');
+
+ga('create', 'UA-XXXXX-Y', 'auto');
+ga('send', 'pageview');
+</script>
+<!-- End Google Analytics -->
+
+```
+
+Since you are serving the resource from your own server, you control the headers that come along with it, including the `Access-Control-Allow-Origin` header that the proxy work-around is sometimes needed for.
+
+As a bonus, serving these resources locally is one less DNS lookup that needs to happen before the client can load your site.
+
+You can manually download these self-hosted third-party JavaScript resources, or you can use a webpack plugin like [save-remote-file-webpack-plugin](https://www.npmjs.com/package/save-remote-file-webpack-plugin) to do it as part of your build process:
+
+```js
+const SaveRemoteFilePlugin = require('save-remote-file-webpack-plugin');
+module.exports = {
+    plugins: [
+        new SaveRemoteFilePlugin([
+            {
+                url: 'https://google-analytics.com/analytics.js',
+                filepath: 'js/analytics.js',
+            },
+        ])
+    ]
+}
+```


### PR DESCRIPTION
Documents how you can work-around the need for a proxy by downloading and serving third-party JavaScript resources locally.