### PR TITLE
feat: rollup/vite copylib plugin

### DIFF
--- a/docs/facebook-pixel.md
+++ b/docs/facebook-pixel.md
@@ -33,9 +33,10 @@ Facebook Pixel uses the [fbq()](https://www.facebook.com/business/help/402791146
   resolveUrl={function(url) {
     if (url.hostname === "connect.facebook.net") {
       var proxyUrl = new URL('https://my-reverse-proxy.com/');
-      proxyUrl.searchParams.append('url', url);
+      proxyUrl.searchParams.append('url', url.href);
       return proxyUrl;
     }
+    return url;
   },
   forward: [
     "fbq"

--- a/docs/proxying-requests.md
+++ b/docs/proxying-requests.md
@@ -33,7 +33,7 @@ partytown = {
   resolveUrl: function (url) {
     if (url.hostname === 'www.google-analytics.com') {
       var proxyUrl = new URL('https://my-reverse-proxy.com/');
-      proxyUrl.searchParams.append('url', url);
+      proxyUrl.searchParams.append('url', url.href);
       return proxyUrl;
     }
     return url;
@@ -62,13 +62,13 @@ So instead of inserting something like this on your page for [Google Analytics](
 ```html
 <!-- Google Analytics -->
 <script type="text/partytown">
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-ga('create', 'UA-XXXXX-Y', 'auto');
-ga('send', 'pageview');
+  ga('create', 'UA-XXXXX-Y', 'auto');
+  ga('send', 'pageview');
 </script>
 <!-- End Google Analytics -->
 ```
@@ -78,16 +78,15 @@ You instead download the `analytics.js` JavaScript resource, and serve it locall
 ```html
 <!-- Google Analytics -->
 <script type="text/partytown">
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://example.com/analytics.js','ga');
+  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+  })(window,document,'script','https://example.com/analytics.js','ga');
 
-ga('create', 'UA-XXXXX-Y', 'auto');
-ga('send', 'pageview');
+  ga('create', 'UA-XXXXX-Y', 'auto');
+  ga('send', 'pageview');
 </script>
 <!-- End Google Analytics -->
-
 ```
 
 Since you are serving the resource from your own server, you control the headers that come along with it, including the `Access-Control-Allow-Origin` header that the proxy work-around is sometimes needed for.
@@ -99,13 +98,13 @@ You can manually download these self-hosted third-party JavaScript resources, or
 ```js
 const SaveRemoteFilePlugin = require('save-remote-file-webpack-plugin');
 module.exports = {
-    plugins: [
-        new SaveRemoteFilePlugin([
-            {
-                url: 'https://google-analytics.com/analytics.js',
-                filepath: 'js/analytics.js',
-            },
-        ])
-    ]
-}
+  plugins: [
+    new SaveRemoteFilePlugin([
+      {
+        url: 'https://google-analytics.com/analytics.js',
+        filepath: 'js/analytics.js',
+      },
+    ]),
+  ],
+};
 ```

--- a/src/utils/api.md
+++ b/src/utils/api.md
@@ -18,6 +18,20 @@ export interface CopyLibFilesOptions {
 // @public
 export function libDirPath(): string;
 
+// @public (undocumented)
+export interface PartytownRollupOptions {
+    debug?: boolean;
+    dest: string;
+}
+
+// @public
+function rollupPartytownCopyLib(opts: PartytownRollupOptions): {
+    name: string;
+    writeBundle(): Promise<void>;
+};
+export { rollupPartytownCopyLib }
+export { rollupPartytownCopyLib as vitePartytownCopyLib }
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/src/utils/api.md
+++ b/src/utils/api.md
@@ -24,23 +24,23 @@ export interface LibDirOptions {
 export function libDirPath(opts?: LibDirOptions): string;
 
 // @public
-export function rollupPartytown(opts: RollupPartytownOptions): {
+export function partytownRollup(opts: PartytownRollupOptions): {
     name: string;
 };
 
 // @public (undocumented)
-export interface RollupPartytownOptions {
+export interface PartytownRollupOptions {
     debug?: boolean;
     dest: string;
 }
 
 // @public
-export function vitePartytown(opts: VitePartytownOptions): {
+export function partytownVite(opts: PartytownViteOptions): {
     name: string;
 };
 
 // @public (undocumented)
-export interface VitePartytownOptions extends RollupPartytownOptions {
+export interface PartytownViteOptions extends PartytownRollupOptions {
 }
 
 // (No @packageDocumentation comment for this package)

--- a/src/utils/api.md
+++ b/src/utils/api.md
@@ -5,7 +5,7 @@
 ```ts
 
 // @public
-export function copyLibFiles(destDir: string, opts?: CopyLibFilesOptions): Promise<{
+export function copyLibFiles(dest: string, opts?: CopyLibFilesOptions): Promise<{
     src: string;
     dest: string;
 }>;
@@ -15,22 +15,33 @@ export interface CopyLibFilesOptions {
     debugDir?: boolean;
 }
 
+// @public (undocumented)
+export interface LibDirOptions {
+    debugDir?: boolean;
+}
+
 // @public
-export function libDirPath(): string;
+export function libDirPath(opts?: LibDirOptions): string;
+
+// @public
+export function rollupPartytown(opts: RollupPartytownOptions): {
+    name: string;
+};
 
 // @public (undocumented)
-export interface PartytownRollupOptions {
+export interface RollupPartytownOptions {
     debug?: boolean;
     dest: string;
 }
 
 // @public
-function rollupPartytownCopyLib(opts: PartytownRollupOptions): {
+export function vitePartytown(opts: VitePartytownOptions): {
     name: string;
-    writeBundle(): Promise<void>;
 };
-export { rollupPartytownCopyLib }
-export { rollupPartytownCopyLib as vitePartytownCopyLib }
+
+// @public (undocumented)
+export interface VitePartytownOptions extends RollupPartytownOptions {
+}
 
 // (No @packageDocumentation comment for this package)
 

--- a/src/utils/copy-lib-files.ts
+++ b/src/utils/copy-lib-files.ts
@@ -1,14 +1,5 @@
-import fs from 'fs';
-import { dirname, isAbsolute, resolve } from 'path';
-import { fileURLToPath } from 'url';
-import { promisify } from 'util';
-
-const copyFile = promisify(fs.copyFile);
-const mkdir = promisify(fs.mkdir);
-const readdir = promisify(fs.readdir);
-const stat = promisify(fs.stat);
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
+import { copyFile, mkdir, readdir, stat, __dirname } from './fs';
+import { isAbsolute, resolve } from 'path';
 
 /**
  * Absolute path to the Partytown lib directory within the
@@ -18,7 +9,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
  *
  * @public
  */
-export function libDirPath() {
+export function libDirPath(opts?: LibDirOptions) {
+  if (opts && opts.debugDir) {
+    return resolve(__dirname, '..', 'lib', 'debug');
+  }
   return resolve(__dirname, '..', 'lib');
 }
 
@@ -87,6 +81,17 @@ export interface CopyLibFilesOptions {
   /**
    * When set to `false` the `lib/debug` directory will not be copied. The default is
    * that both the production and debug directories are copied to the destination.
+   */
+  debugDir?: boolean;
+}
+
+/**
+ * @public
+ */
+export interface LibDirOptions {
+  /**
+   * When the `debugDir` option is set to `true`, the returned
+   * directory is the absolute path to the `lib/debug` directory.
    */
   debugDir?: boolean;
 }

--- a/src/utils/fs.ts
+++ b/src/utils/fs.ts
@@ -1,0 +1,12 @@
+import fs from 'fs';
+import { dirname } from 'path';
+import { promisify } from 'util';
+import { fileURLToPath } from 'url';
+
+export const copyFile = promisify(fs.copyFile);
+export const mkdir = promisify(fs.mkdir);
+export const readdir = promisify(fs.readdir);
+export const readFile = promisify(fs.readFile);
+export const stat = promisify(fs.stat);
+
+export const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,8 @@
 export { copyLibFiles, libDirPath } from './copy-lib-files';
-export type { CopyLibFilesOptions } from './copy-lib-files';
+export type { CopyLibFilesOptions, LibDirOptions } from './copy-lib-files';
 
-export { rollupPartytownCopyLib, vitePartytownCopyLib } from './rollup';
-export type { PartytownRollupOptions } from './rollup';
+export { rollupPartytown } from './rollup';
+export type { RollupPartytownOptions } from './rollup';
+
+export { vitePartytown } from './vite';
+export type { VitePartytownOptions } from './vite';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,8 +1,8 @@
 export { copyLibFiles, libDirPath } from './copy-lib-files';
 export type { CopyLibFilesOptions, LibDirOptions } from './copy-lib-files';
 
-export { rollupPartytown } from './rollup';
-export type { RollupPartytownOptions } from './rollup';
+export { partytownRollup } from './rollup';
+export type { PartytownRollupOptions } from './rollup';
 
-export { vitePartytown } from './vite';
-export type { VitePartytownOptions } from './vite';
+export { partytownVite } from './vite';
+export type { PartytownViteOptions } from './vite';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,2 +1,5 @@
 export { copyLibFiles, libDirPath } from './copy-lib-files';
 export type { CopyLibFilesOptions } from './copy-lib-files';
+
+export { rollupPartytownCopyLib, vitePartytownCopyLib } from './rollup';
+export type { PartytownRollupOptions } from './rollup';

--- a/src/utils/rollup.ts
+++ b/src/utils/rollup.ts
@@ -2,7 +2,7 @@ import { isAbsolute } from 'path';
 import { copyLibFiles } from './copy-lib-files';
 
 /** @public */
-export interface PartytownRollupOptions {
+export interface RollupPartytownOptions {
   /** An absolute path to the destination directory where the lib files should be copied. */
   dest: string;
 
@@ -20,21 +20,21 @@ export interface PartytownRollupOptions {
  *
  * @public
  */
-export function rollupPartytownCopyLib(opts: PartytownRollupOptions) {
-  opts = opts || {};
+export function rollupPartytown(opts: RollupPartytownOptions) {
+  opts = opts || ({} as any);
 
-  if (typeof opts.dest !== 'string') {
-    throw new Error(`Partytown copylib plugin must have "dest" property.`);
+  if (typeof opts.dest !== 'string' || opts.dest.length === 0) {
+    throw new Error(`Partytown plugin must have "dest" property.`);
   }
 
   if (!isAbsolute(opts.dest)) {
-    throw new Error(`Partytown copylib plugin "dest" property must be an absolute path.`);
+    throw new Error(`Partytown plugin "dest" property must be an absolute path.`);
   }
 
   let hasCopied = false;
 
-  return {
-    name: 'partytown-copylib',
+  const plugin = {
+    name: 'rollup-plugin-partytown',
     async writeBundle() {
       if (!hasCopied) {
         await copyLibFiles(opts.dest, { debugDir: opts.debug });
@@ -42,13 +42,6 @@ export function rollupPartytownCopyLib(opts: PartytownRollupOptions) {
       }
     },
   };
-}
 
-/**
- * Vite plugin to copy Partytown `lib` directory to the given destination.
- *
- * https://partytown.builder.io/copy-library-files
- *
- * @public
- */
-export { rollupPartytownCopyLib as vitePartytownCopyLib };
+  return plugin as { name: string };
+}

--- a/src/utils/rollup.ts
+++ b/src/utils/rollup.ts
@@ -2,7 +2,7 @@ import { isAbsolute } from 'path';
 import { copyLibFiles } from './copy-lib-files';
 
 /** @public */
-export interface RollupPartytownOptions {
+export interface PartytownRollupOptions {
   /** An absolute path to the destination directory where the lib files should be copied. */
   dest: string;
 
@@ -20,7 +20,7 @@ export interface RollupPartytownOptions {
  *
  * @public
  */
-export function rollupPartytown(opts: RollupPartytownOptions) {
+export function partytownRollup(opts: PartytownRollupOptions) {
   opts = opts || ({} as any);
 
   if (typeof opts.dest !== 'string' || opts.dest.length === 0) {

--- a/src/utils/rollup.ts
+++ b/src/utils/rollup.ts
@@ -1,0 +1,54 @@
+import { isAbsolute } from 'path';
+import { copyLibFiles } from './copy-lib-files';
+
+/** @public */
+export interface PartytownRollupOptions {
+  /** An absolute path to the destination directory where the lib files should be copied. */
+  dest: string;
+
+  /**
+   * When `debug` is set to `false`, the `lib/debug` directory will not be copied.
+   * The default is that both the production and debug directories are copied to the destination.
+   */
+  debug?: boolean;
+}
+
+/**
+ * Rollup plugin to copy Partytown `lib` directory to the given destination.
+ *
+ * https://partytown.builder.io/copy-library-files
+ *
+ * @public
+ */
+export function rollupPartytownCopyLib(opts: PartytownRollupOptions) {
+  opts = opts || {};
+
+  if (typeof opts.dest !== 'string') {
+    throw new Error(`Partytown copylib plugin must have "dest" property.`);
+  }
+
+  if (!isAbsolute(opts.dest)) {
+    throw new Error(`Partytown copylib plugin "dest" property must be an absolute path.`);
+  }
+
+  let hasCopied = false;
+
+  return {
+    name: 'partytown-copylib',
+    async writeBundle() {
+      if (!hasCopied) {
+        await copyLibFiles(opts.dest, { debugDir: opts.debug });
+        hasCopied = true;
+      }
+    },
+  };
+}
+
+/**
+ * Vite plugin to copy Partytown `lib` directory to the given destination.
+ *
+ * https://partytown.builder.io/copy-library-files
+ *
+ * @public
+ */
+export { rollupPartytownCopyLib as vitePartytownCopyLib };

--- a/src/utils/vite.ts
+++ b/src/utils/vite.ts
@@ -1,12 +1,12 @@
 import { libDirPath } from './copy-lib-files';
-import type { RollupPartytownOptions } from './rollup';
-import { rollupPartytown } from './rollup';
+import type { PartytownRollupOptions } from './rollup';
+import { partytownRollup } from './rollup';
 import { join } from 'path';
 import { readFile } from './fs';
 import type { IncomingMessage, ServerResponse } from 'http';
 
 /** @public */
-export interface VitePartytownOptions extends RollupPartytownOptions {}
+export interface PartytownViteOptions extends PartytownRollupOptions {}
 
 /**
  * Vite plugin to copy Partytown `lib` directory to the given destination.
@@ -18,10 +18,10 @@ export interface VitePartytownOptions extends RollupPartytownOptions {}
  *
  * @public
  */
-export function vitePartytown(opts: VitePartytownOptions) {
+export function partytownVite(opts: PartytownViteOptions) {
   opts = opts || ({} as any);
 
-  const plugin: any = rollupPartytown(opts);
+  const plugin: any = partytownRollup(opts);
 
   plugin.name = 'vite-plugin-partytown';
 

--- a/src/utils/vite.ts
+++ b/src/utils/vite.ts
@@ -1,0 +1,61 @@
+import { libDirPath } from './copy-lib-files';
+import type { RollupPartytownOptions } from './rollup';
+import { rollupPartytown } from './rollup';
+import { join } from 'path';
+import { readFile } from './fs';
+import type { IncomingMessage, ServerResponse } from 'http';
+
+/** @public */
+export interface VitePartytownOptions extends RollupPartytownOptions {}
+
+/**
+ * Vite plugin to copy Partytown `lib` directory to the given destination.
+ *
+ * When in dev mode, the Partytown lib files will be served
+ * from the Vite Dev Server.
+ *
+ * https://partytown.builder.io/copy-library-files
+ *
+ * @public
+ */
+export function vitePartytown(opts: VitePartytownOptions) {
+  opts = opts || ({} as any);
+
+  const plugin: any = rollupPartytown(opts);
+
+  plugin.name = 'vite-plugin-partytown';
+
+  plugin.configureServer = (server: any) => {
+    if (server) {
+      server.middlewares.use(
+        async (req: IncomingMessage, res: ServerResponse, next: () => void) => {
+          try {
+            const pathname = req.url;
+            if (pathname && pathname.includes('/~partytown/')) {
+              const fileName = pathname.split('/').pop();
+              if (fileName && fileName.endsWith('.js')) {
+                const libDir = libDirPath({ debugDir: pathname.includes('/debug/') });
+                const filePath = join(libDir, fileName);
+                const buf = await readFile(filePath);
+                res.writeHead(200, {
+                  'Content-Type': 'application/javascript; charset=utf-8',
+                  'X-Vite-Dev-Sever-Partytown': ':tada:',
+                });
+                res.end(buf);
+                return;
+              }
+            }
+          } catch (e) {
+            console.error(`vitePartytownCopyLib.configureServer`, e);
+          }
+
+          next();
+        }
+      );
+    }
+  };
+
+  return plugin as {
+    name: string;
+  };
+}


### PR DESCRIPTION
Provides `rollupPartytownCopyLib()` and `vitePartytownCopyLib()` plugins to copy the lib directories to a destination.