### PR TITLE
Add forms property

### DIFF
--- a/src/lib/web-worker/worker-document.ts
+++ b/src/lib/web-worker/worker-document.ts
@@ -172,7 +172,7 @@ export const patchDocument = (WorkerDocument: any) => {
 
   definePrototypePropertyDescriptor(WorkerDocument, DocumentDescriptorMap);
 
-  cachedProps(WorkerDocument, 'compatMode,referrer');
+  cachedProps(WorkerDocument, 'compatMode,referrer,forms');
 };
 
 export const patchDocumentElementChild = (WokerDocumentElementChild: any) => {

--- a/tests/platform/document/document.spec.ts
+++ b/tests/platform/document/document.spec.ts
@@ -73,6 +73,9 @@ test('document', async ({ page }) => {
   const testDocumentChildNodes = page.locator('#testDocumentChildNodes');
   await expect(testDocumentChildNodes).toHaveText('2 [html(10), HTML(1)]');
 
+  const testDocumentForms = page.locator('#testDocumentForms');
+  await expect(testDocumentForms).toHaveText('0');
+
   const testDocType = page.locator('#testDocType');
   await expect(testDocType).toHaveText('10 html html false');
 

--- a/tests/platform/document/index.html
+++ b/tests/platform/document/index.html
@@ -334,6 +334,18 @@
       </li>
 
       <li>
+        <strong>document.forms</strong>
+        <code id="testDocumentForms"></code>
+        <script type="text/partytown">
+          (function () {
+            const elm = document.getElementById('testDocumentForms');
+            const forms = document.forms;
+            elm.textContent = `${forms.length}`;
+          })();
+        </script>
+      </li>
+
+      <li>
         <strong>DocumentType node</strong>
         <code id="testDocType"></code>
         <script type="text/partytown">


### PR DESCRIPTION
This PR adds the [forms](https://developer.mozilla.org/en-US/docs/Web/API/Document/forms) property to the document object