### PR TITLE
fix: remove script length check when initializing service worker

### DIFF
--- a/src/lib/main/snippet.ts
+++ b/src/lib/main/snippet.ts
@@ -34,7 +34,7 @@ export function snippet(
         if (top != win) {
           // this is an iframe
           top!.dispatchEvent(new CustomEvent('pt1', { detail: win }));
-        } else if (scripts!.length) {
+        } else {
           // set a timeout to fire if PT hasn't initialized in Xms
           timeout = setTimeout(fallback, 10000);
           doc.addEventListener('pt0', clearFallback);
@@ -65,8 +65,6 @@ export function snippet(
             // no support for atomics or service worker
             fallback();
           }
-        } else if (debug && scripts!.length === 0) {
-          console.debug('No Partytown scripts found');
         }
       } else if (debug) {
         console.warn('Partytown config.lib url must start with "/"');


### PR DESCRIPTION
Remove Script Length check to ensure service workers are always initialized regardless of whether any text/partytown scripts are present or not.

This is to ensure that we can handle pages which load text/partytown scripts async, which are sometimes loaded after the initial check for partytown is done.