### PR TITLE
Add a failing test for window customElements

### DIFF
--- a/tests/platform/window/index.html
+++ b/tests/platform/window/index.html
@@ -710,6 +710,32 @@
         </script>
       </li>
 
+      <li>
+        <strong>CustomElements</strong>
+        <code id="testWindowCustomElements"></code>
+        <script type="text/partytown">
+          (function () {
+            const elm = document.getElementById('testWindowCustomElements');
+            class MyTitle extends HTMLElement {
+              connectedCallback() {
+                this.innerHTML = `
+                  <style>
+                    h1 {
+                      font-size: 2.5rem;
+                      color: hotpink;
+                    }
+                  </style>
+                  <h1>Hello Alligator!</h1>
+                `;
+              }
+            }
+
+            customElements.define('my-title', MyTitle);
+            elm.textContent = typeof customElements.get('my-title');
+          })();
+        </script>
+      </li>
+
       <script type="text/partytown">
         (function () {
           document.body.classList.add('completed');

--- a/tests/platform/window/window.spec.ts
+++ b/tests/platform/window/window.spec.ts
@@ -142,4 +142,7 @@ test('window', async ({ page }) => {
 
   const testWorkerGlobalScope = page.locator('#testWorkerGlobalScope');
   await expect(testWorkerGlobalScope).toHaveText('false');
+
+  const testCustomElements = page.locator('#testCustomElements');
+  await expect(testCustomElements).toHaveText('');
 });


### PR DESCRIPTION
The PixC resize library in Shopify defines and uses its own custom elements, which is failing right now.

Added a failing test in the window element to replicate the same behavior