### PR TITLE
fix: allow for _ as an acceptable element in document.createElement

### DIFF
--- a/src/lib/web-worker/worker-constants.ts
+++ b/src/lib/web-worker/worker-constants.ts
@@ -82,4 +82,4 @@ export const nonBlockingMethods = /*#__PURE__*/ eventTargetMethods.concat(
   /*#__PURE__*/ commaSplit('add,observe,remove,unobserve')
 );
 
-export const IS_TAG_REG = /^[A-Z]([A-Z0-9-]*[A-Z0-9])?$/;
+export const IS_TAG_REG = /^[A-Z_]([A-Z0-9-]*[A-Z0-9])?$/;

--- a/tests/platform/document/document.spec.ts
+++ b/tests/platform/document/document.spec.ts
@@ -88,6 +88,9 @@ test('document', async ({ page }) => {
   const testCreateElementError = page.locator('#testCreateElementError');
   await expect(testCreateElementError).toHaveText('errored');
 
+  const testCreateElementError_ = page.locator('#testCreateElementError_');
+  await expect(testCreateElementError_).toHaveText('no error');
+
   const testCreateHTMLDocument = page.locator('#testCreateHTMLDocument');
   await expect(testCreateHTMLDocument).toHaveText('88mph hidden');
 

--- a/tests/platform/document/index.html
+++ b/tests/platform/document/index.html
@@ -411,6 +411,22 @@
       </li>
 
       <li>
+        <strong>createElement _ error</strong>
+        <code id="testCreateElementError_"></code>
+        <script type="text/partytown">
+          (function () {
+            const elm = document.getElementById('testCreateElementError_');
+            try {
+              document.createElement('_');
+              elm.textContent = 'no error';
+            } catch (e) {
+              elm.textContent = 'errored';
+            }
+          })();
+        </script>
+      </li>
+
+      <li>
         <strong>implementation.createHTMLDocument("")</strong>
         <code id="testCreateHTMLDocument"></code>
         <script type="text/partytown">


### PR DESCRIPTION
The classList polyfill (https://github.com/eligrey/classList.js/blob/master/classList.js) creates an element `_`. 

This PR changes the regex checking if an element name is valid to allow for `_`