### PR TITLE
docs(nuxt): use capitalised script tag

### DIFF
--- a/docs/nuxt.md
+++ b/docs/nuxt.md
@@ -34,7 +34,7 @@ Add `type: 'text/partytown'` [attribute](/partytown-scripts) to any scripts you 
 ```html
 <template>
   <div>
-    <script type="text/partytown" src="https://example.com/analytics.js" />
+    <Script type="text/partytown" src="https://example.com/analytics.js" />
   </div>
 </template>
 ```


### PR DESCRIPTION
it's important this tag is uppercase as it's a custom meta tag rather than the native html element