### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -210,9 +210,9 @@ const getLogValue = (applyPath: ApplyPath, v: any): string => {
   }
   if (type === 'string') {
     if (applyPath.includes('cookie')) {
-      return JSON.stringify(v.substr(0, 10) + '...');
+      return JSON.stringify(v.slice(0, 10) + '...');
     }
-    return JSON.stringify(v.length > 50 ? v.substr(0, 40) + '...' : v);
+    return JSON.stringify(v.length > 50 ? v.slice(0, 40) + '...' : v);
   }
   if (Array.isArray(v)) {
     return `[${v.map(getLogValue).join(', ')}]`;


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.