### PR TITLE
Laravel mix Integration

### DIFF
--- a/docs/copy-library-files.md
+++ b/docs/copy-library-files.md
@@ -113,3 +113,14 @@ module.exports = {
   ],
 };
 ```
+## Laravel Mix
+
+Below is an example of using [Mix's copy()](https://laravel-mix.com/docs/6.0/copying-files/) to copy the source `lib` directory found in the [@builder.io/partytown](https://www.npmjs.com/package/@builder.io/partytown) package, to the `public/~partytown/` directory:
+
+```js
+// webpack.mix.js
+const mix = require('laravel-mix');
+const partytown = require('@builder.io/partytown/utils');
+
+mix.copy(partytown.libDirPath(), 'dist/~partytown');
+```

--- a/docs/copy-library-files.md
+++ b/docs/copy-library-files.md
@@ -122,5 +122,5 @@ Below is an example of using [Mix's copy()](https://laravel-mix.com/docs/6.0/cop
 const mix = require('laravel-mix');
 const partytown = require('@builder.io/partytown/utils');
 
-mix.copy(partytown.libDirPath(), 'dist/~partytown');
+mix.copy(partytown.libDirPath(), 'public/~partytown');
 ```


### PR DESCRIPTION
A common use case for this is when you wish to move a set of fonts, installed through NPM, to your public directory with the copy command.
I google it for hours and I couldn't find a way of integrating **Partytown** in my `laravel mix bundler` which is built on top of webpack they provide a such fluent way to copy the `lib `to the public assets, i hope that will be helpful for developers who look for it in the future 