### PR TITLE
fix (docs): builder link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The philosophy is that the main thread should be dedicated to your code, and any
 
 - [Qwik](https://github.com/BuilderIO/qwik): An open-source framework designed for best possible time to interactive, by focusing on resumability of server-side-rendering of HTML, and fine-grained lazy-loading of code.
 - [Mitosis](https://github.com/BuilderIO/mitosis): Write components once, run everywhere. Compiles to Vue, React, Solid, Angular, Svelte, and more.
-- [Builder](https://github.com/BuilderIO): Drag and drop page builder and CMS for React, Vue, Angular, and more.
+- [Builder](https://github.com/BuilderIO/builder): Drag and drop page builder and CMS for React, Vue, Angular, and more.
 
 ---
 


### PR DESCRIPTION
Added missing repo name in the `builder` link