### PR TITLE
Better Regex to ignore $this variables in the code

### DIFF
--- a/src/lib/web-worker/worker-exec.ts
+++ b/src/lib/web-worker/worker-exec.ts
@@ -109,7 +109,7 @@ export const run = (env: WebWorkerEnvironment, scriptContent: string, scriptUrl?
         .filter((globalFnName) => /[a-zA-Z_$][0-9a-zA-Z_$]*/.test(globalFnName))
         .map((g) => `(typeof ${g}=='function'&&(window.${g}=${g}))`)
         .join(';') +
-      scriptContent.replace(/\bthis\b/g, '(thi$(this)?window:this)').replace(/\/\/# so/g, '//Xso')
+      scriptContent.replace(/(?<!\$)\bthis\b/g, '(thi$(this)?window:this)').replace(/\/\/# so/g, '//Xso')
     }\n;function thi$(t){return t===this}}` + (scriptUrl ? '\n//# sourceURL=' + scriptUrl : '');
 
   if (!env.$isSameOrigin$) {


### PR DESCRIPTION
At this moment the regex matches with the word `this` but also with `$this`, that should not be the case. This way `$this` is ignored from being replaced, this is used in some 3rd party scripts. 