### PR TITLE
Propagate pushState/replaceState inside worker

### DIFF
--- a/src/lib/sandbox/main-register-window.ts
+++ b/src/lib/sandbox/main-register-window.ts
@@ -29,17 +29,18 @@ export const registerWindow = (
     const pushState = history.pushState.bind(history);
     const replaceState = history.replaceState.bind(history);
 
-    const onLocationChange = (type: LocationUpdateType, state: object, newUrl?: string, oldUrl?: string) =>
+    const onLocationChange = (type: LocationUpdateType, state: object, newUrl?: string, oldUrl?: string) => {
       setTimeout(() =>{
         worker.postMessage([WorkerMessageType.LocationUpdate, {
           $winId$,
           type,
           state,
+          url: doc.baseURI,
           newUrl,
           oldUrl
         }])
-
       });
+    }
 
     history.pushState = (state, _, newUrl) => {
       pushState(state, _, newUrl);

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -90,6 +90,7 @@ export interface LocationUpdateData {
   $winId$: WinId;
   type: LocationUpdateType,
   state: object;
+  url: string;
   newUrl?: string;
   oldUrl?: string;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -50,7 +50,7 @@ export type MessageFromSandboxToWorker =
   | [type: WorkerMessageType.InitializedScripts, winId: WinId]
   | [type: WorkerMessageType.RefHandlerCallback, callbackData: RefHandlerCallbackData]
   | [type: WorkerMessageType.ForwardMainTrigger, triggerData: ForwardMainTriggerData]
-  | [type: WorkerMessageType.LocationUpdate, winId: WinId, documentBaseURI: string]
+  | [type: WorkerMessageType.LocationUpdate, locationChangeData: LocationUpdateData]
   | [type: WorkerMessageType.DocumentVisibilityState, winId: WinId, visibilityState: string]
   | [
       type: WorkerMessageType.CustomElementCallback,
@@ -77,6 +77,21 @@ export const enum WorkerMessageType {
   LocationUpdate,
   DocumentVisibilityState,
   CustomElementCallback,
+}
+
+export const enum LocationUpdateType {
+  PushState,
+  ReplaceState,
+  PopState,
+  HashChange
+}
+
+export interface LocationUpdateData {
+  $winId$: WinId;
+  type: LocationUpdateType,
+  state: object;
+  newUrl?: string;
+  oldUrl?: string;
 }
 
 export interface ForwardMainTriggerData {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -194,6 +194,7 @@ export interface WebWorkerEnvironment {
   $runWindowLoadEvent$?: number;
   $isSameOrigin$?: boolean;
   $isTopWindow$?: boolean;
+  $propagateHistoryChange$?: boolean;
 }
 
 export interface MembersInterfaceTypeInfo {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -349,7 +349,6 @@ export type SerializedTransfer =
   | SerializedNodeListTransfer
   | SerializedObjectTransfer
   | SerializedPrimitiveTransfer
-  | SerializedPrimitiveTransfer
   | SerializedRefTransfer
   | [];
 

--- a/src/lib/web-worker/index.ts
+++ b/src/lib/web-worker/index.ts
@@ -46,9 +46,7 @@ const receiveMessageFromSandboxToWorker = (ev: MessageEvent<MessageFromSandboxTo
 
       forwardLocationChange(msgValue.$winId$, env, msgValue);
 
-      if (msgValue.newUrl) {
-        env.$location$.href = msgValue.newUrl;
-      }
+      env.$location$.href = msgValue.url;
     } else if (msgType === WorkerMessageType.CustomElementCallback) {
       callCustomElementCallback(...msg);
     }

--- a/src/lib/web-worker/index.ts
+++ b/src/lib/web-worker/index.ts
@@ -8,6 +8,7 @@ import { initNextScriptsInWebWorker } from './worker-exec';
 import { initWebWorker } from './init-web-worker';
 import { logWorker, normalizedWinId } from '../log';
 import { workerForwardedTriggerHandle } from './worker-forwarded-trigger';
+import { forwardLocationChange } from "./worker-location";
 
 const queuedEvents: MessageEvent<MessageFromSandboxToWorker>[] = [];
 
@@ -40,7 +41,14 @@ const receiveMessageFromSandboxToWorker = (ev: MessageEvent<MessageFromSandboxTo
     } else if (msgType === WorkerMessageType.DocumentVisibilityState) {
       environments[msgValue].$visibilityState$ = msg[2];
     } else if (msgType === WorkerMessageType.LocationUpdate) {
-      environments[msgValue].$location$.href = msg[2];
+      const $winId$ = msgValue.$winId$;
+      const env = environments[$winId$];
+
+      forwardLocationChange(msgValue.$winId$, env, msgValue);
+
+      if (msgValue.newUrl) {
+        env.$location$.href = msgValue.newUrl;
+      }
     } else if (msgType === WorkerMessageType.CustomElementCallback) {
       callCustomElementCallback(...msg);
     }

--- a/src/lib/web-worker/worker-constants.ts
+++ b/src/lib/web-worker/worker-constants.ts
@@ -19,6 +19,7 @@ export const ApplyPathKey = /*#__PURE__*/ Symbol();
 export const InstanceStateKey = /*#__PURE__*/ Symbol();
 export const HookContinue = /*#__PURE__*/ Symbol();
 export const HookPrevent = /*#__PURE__*/ Symbol();
+export const HistoryChangePrevent = /*#__PURE__*/ Symbol();
 
 export const webWorkerInstances = /*#__PURE__*/ new Map<InstanceId, WorkerNode>();
 export const webWorkerRefsByRefId: { [refId: RefId]: RefHandler } = {};

--- a/src/lib/web-worker/worker-constants.ts
+++ b/src/lib/web-worker/worker-constants.ts
@@ -19,7 +19,6 @@ export const ApplyPathKey = /*#__PURE__*/ Symbol();
 export const InstanceStateKey = /*#__PURE__*/ Symbol();
 export const HookContinue = /*#__PURE__*/ Symbol();
 export const HookPrevent = /*#__PURE__*/ Symbol();
-export const HistoryChangePrevent = /*#__PURE__*/ Symbol();
 
 export const webWorkerInstances = /*#__PURE__*/ new Map<InstanceId, WorkerNode>();
 export const webWorkerRefsByRefId: { [refId: RefId]: RefHandler } = {};

--- a/src/lib/web-worker/worker-location.ts
+++ b/src/lib/web-worker/worker-location.ts
@@ -3,14 +3,6 @@ import { HistoryChangePrevent } from "./worker-constants";
 
 const isObject = (value: any) => typeof value === 'object' && value !== null;
 
-type PopStateEvent = Event & {
-  state?: LocationUpdateData['state'];
-};
-type HashChangeEvent = Event & {
-  newURL?: LocationUpdateData['newUrl'],
-  oldURL?: LocationUpdateData['oldUrl']
-};
-
 export function forwardLocationChange($winId$: number, env: WebWorkerEnvironment, data: LocationUpdateData) {
   const history = env.$window$.history;
 
@@ -26,23 +18,6 @@ export function forwardLocationChange($winId$: number, env: WebWorkerEnvironment
         history.replaceState({...data.state, [HistoryChangePrevent]: true}, '', data.newUrl)
       }
       break;
-    }
-    case LocationUpdateType.PopState: {
-      // FIXME: This WILL cause infinite loop for now
-      // debugger;
-      const event: PopStateEvent = new Event('popstate');
-      event.state = data.state;
-      env.$window$.dispatchEvent(event);
-      break;
-    }
-    case LocationUpdateType.HashChange: {
-      // FIXME: This WILL cause infinite loop for now
-      // debugger;
-      const event: HashChangeEvent = new Event('hashchange', )
-      event.newURL = data.newUrl;
-      event.oldURL = data.oldUrl;
-      env.$window$.dispatchEvent(event);
-      break
     }
   }
 }

--- a/src/lib/web-worker/worker-location.ts
+++ b/src/lib/web-worker/worker-location.ts
@@ -6,13 +6,17 @@ export function forwardLocationChange($winId$: number, env: WebWorkerEnvironment
   switch (data.type) {
     case LocationUpdateType.PushState: {
       env.$propagateHistoryChange$ = false;
-      history.pushState(data.state, '', data.newUrl)
+      try {
+        history.pushState(data.state, '', data.newUrl)
+      } catch (e) {}
       env.$propagateHistoryChange$ = true;
       break;
     }
     case LocationUpdateType.ReplaceState: {
       env.$propagateHistoryChange$ = false;
-      history.replaceState(data.state, '', data.newUrl)
+      try {
+        history.replaceState(data.state, '', data.newUrl)
+      } catch (e) {}
       env.$propagateHistoryChange$ = true;
       break;
     }

--- a/src/lib/web-worker/worker-location.ts
+++ b/src/lib/web-worker/worker-location.ts
@@ -1,22 +1,19 @@
 import { LocationUpdateData, LocationUpdateType, WebWorkerEnvironment } from "../types";
-import { HistoryChangePrevent } from "./worker-constants";
-
-const isObject = (value: any) => typeof value === 'object' && value !== null;
 
 export function forwardLocationChange($winId$: number, env: WebWorkerEnvironment, data: LocationUpdateData) {
   const history = env.$window$.history;
 
   switch (data.type) {
     case LocationUpdateType.PushState: {
-      if (isObject(data.state)) {
-        history.pushState({...data.state, [HistoryChangePrevent]: true}, '', data.newUrl)
-      }
+      env.$propagateHistoryChange$ = false;
+      history.pushState(data.state, '', data.newUrl)
+      env.$propagateHistoryChange$ = true;
       break;
     }
     case LocationUpdateType.ReplaceState: {
-      if (isObject(data.state)) {
-        history.replaceState({...data.state, [HistoryChangePrevent]: true}, '', data.newUrl)
-      }
+      env.$propagateHistoryChange$ = false;
+      history.replaceState(data.state, '', data.newUrl)
+      env.$propagateHistoryChange$ = true;
       break;
     }
   }

--- a/src/lib/web-worker/worker-location.ts
+++ b/src/lib/web-worker/worker-location.ts
@@ -1,0 +1,26 @@
+import { LocationUpdateData, LocationUpdateType, WebWorkerEnvironment } from "../types";
+import { HistoryChangePrevent } from "./worker-constants";
+
+const isObject = (value: any) => typeof value === 'object' && value !== null;
+
+export function forwardLocationChange ($winId$: number, env: WebWorkerEnvironment, data: LocationUpdateData) {
+  const history = env.$window$.history;
+
+  switch (data.type) {
+    case LocationUpdateType.PushState: {
+      if (isObject(data.state)) {
+        history.pushState({ ...data.state, [HistoryChangePrevent]: true }, '', data.newUrl)
+      }
+      break;
+    }
+    case LocationUpdateType.ReplaceState: {
+      if (isObject(data.state)) {
+        history.replaceState({...data.state, [HistoryChangePrevent]: true}, '', data.newUrl)
+      }
+      break;
+    }
+    case LocationUpdateType.PopState:
+    case LocationUpdateType.HashChange:
+      break
+  }
+}

--- a/src/lib/web-worker/worker-window.ts
+++ b/src/lib/web-worker/worker-window.ts
@@ -19,7 +19,6 @@ import {
   commaSplit,
   environments,
   eventTargetMethods,
-  HistoryChangePrevent,
   InstanceDataKey,
   InstanceIdKey,
   InstanceStateKey,
@@ -436,16 +435,16 @@ export const createWindow = (
           };
           win.indexeddb = undefined;
         } else {
-          const originalPushState: Window['history']['pushState'] = win.history.pushState;
-          const originalReplaceState: Window['history']['replaceState'] = win.history.replaceState;
+          const originalPushState: Window['history']['pushState'] = win.history.pushState.bind(win.history);
+          const originalReplaceState: Window['history']['replaceState'] = win.history.replaceState.bind(win.history);
 
           win.history.pushState = (stateObj: any, _: string, newUrl?: string) => {
-            if (stateObj[HistoryChangePrevent] !== true) {
+            if (env.$propagateHistoryChange$ !== false) {
               originalPushState(stateObj, _, newUrl)
             }
           }
           win.history.replaceState = (stateObj: any, _: string, newUrl?: string) => {
-            if (stateObj[HistoryChangePrevent] !== true) {
+            if (env.$propagateHistoryChange$ !== false) {
               originalReplaceState(stateObj, _, newUrl)
             }
           }

--- a/src/lib/web-worker/worker-window.ts
+++ b/src/lib/web-worker/worker-window.ts
@@ -19,6 +19,7 @@ import {
   commaSplit,
   environments,
   eventTargetMethods,
+  HistoryChangePrevent,
   InstanceDataKey,
   InstanceIdKey,
   InstanceStateKey,
@@ -433,6 +434,21 @@ export const createWindow = (
             },
             length: 0,
           };
+          win.indexeddb = undefined;
+        } else {
+          const originalPushState: Window['history']['pushState'] = win.history.pushState;
+          const originalReplaceState: Window['history']['replaceState'] = win.history.replaceState;
+
+          win.history.pushState = (stateObj: any, _: string, newUrl?: string) => {
+            if (stateObj[HistoryChangePrevent] !== true) {
+              originalPushState(stateObj, _, newUrl)
+            }
+          }
+          win.history.replaceState = (stateObj: any, _: string, newUrl?: string) => {
+            if (stateObj[HistoryChangePrevent] !== true) {
+              originalReplaceState(stateObj, _, newUrl)
+            }
+          }
         }
 
         win.Worker = undefined;

--- a/tests/platform/history/history.spec.ts
+++ b/tests/platform/history/history.spec.ts
@@ -58,4 +58,14 @@ test('history', async ({ page }) => {
   const buttonIframeReplaceState = page.locator('#buttonIframeReplaceState');
   await buttonIframeReplaceState.click();
   await expect(testIframeReplaceState).toHaveText('88');
+
+  const testMainPushStateEcho = page.locator('#testMainPushStateEcho');
+  const buttonMainPushState = page.locator('#buttonMainPushState');
+  await buttonMainPushState.click();
+  await expect(testMainPushStateEcho).toHaveText('{"state":42,"url":"/tests/platform/history/pushed-state"}');
+
+  const testMainReplaceStateEcho = page.locator('#testMainReplaceStateEcho');
+  const buttonMainReplaceState = page.locator('#buttonMainReplaceState');
+  await buttonMainReplaceState.click();
+  await expect(testMainReplaceStateEcho).toHaveText('{"state":23,"url":"/tests/platform/history"}');
 });

--- a/tests/platform/history/index.html
+++ b/tests/platform/history/index.html
@@ -185,9 +185,11 @@
         <script type="text/partytown">
           (function () {
             const buttonPatchPushState = document.getElementById('buttonPatchPushState');
+            const originalPushState = history.pushState.bind(history);
             buttonPatchPushState.addEventListener('click', () => {
-              history.pushState = function (data, title) {
+              history.pushState = function (data, title, url) {
                 document.getElementById('testPatchPushState').textContent = data + ' Valley';
+                originalPushState(data, title, url);
               };
               history.pushState('Hill', '');
             });
@@ -211,6 +213,57 @@
             buttonIframeReplaceState.addEventListener('click', () => {
               iframe.contentWindow.history.replaceState('88', '');
               elm.textContent = iframe.contentWindow.history.state;
+            });
+          })();
+        </script>
+      </li>
+
+      <li>
+        <strong>main pushState</strong>
+        <button id="buttonMainPushState">main pushState</button>
+        <code id="testMainPushStateEcho"></code>
+        <script type="text/partytown">
+          (function () {
+            const elm = document.getElementById('testMainPushStateEcho');
+
+            const originalPushState = history.pushState.bind(history);
+            history.pushState = function(state, _, url) {
+              originalPushState(state, _, url);
+              elm.textContent = JSON.stringify({ state, url });
+            }
+          })();
+        </script>
+        <script type="text/javascript">
+          (function () {
+            const buttonMainPushState = document.getElementById('buttonMainPushState');
+            buttonMainPushState.addEventListener('click', () => {
+              history.pushState(42, '', '/tests/platform/history/pushed-state');
+            });
+          })();
+        </script>
+      </li>
+
+      <li>
+        <strong>main replaceState</strong>
+        <button id="buttonMainReplaceState">main replaceState</button>
+        <code id="testMainReplaceStateEcho"></code>
+        <script type="text/partytown">
+          (function () {
+            const elm = document.getElementById('testMainReplaceStateEcho');
+
+            const originalReplaceState = history.replaceState.bind(history);
+            history.replaceState = function(state, _, url) {
+              originalReplaceState(state, _, url);
+              elm.textContent = JSON.stringify({ state, url });
+            }
+          })();
+        </script>
+        <script type="text/javascript">
+          (function () {
+            const buttonMainReplaceState = document.getElementById('buttonMainReplaceState');
+
+            buttonMainReplaceState.addEventListener('click', () => {
+              history.replaceState(23, '', '/tests/platform/history');
             });
           })();
         </script>

--- a/tests/platform/history/index.html
+++ b/tests/platform/history/index.html
@@ -185,8 +185,8 @@
         <script type="text/partytown">
           (function () {
             const buttonPatchPushState = document.getElementById('buttonPatchPushState');
-            const originalPushState = history.pushState.bind(history);
             buttonPatchPushState.addEventListener('click', () => {
+              const originalPushState = history.pushState.bind(history);
               history.pushState = function (data, title, url) {
                 document.getElementById('testPatchPushState').textContent = data + ' Valley';
                 originalPushState(data, title, url);
@@ -227,7 +227,9 @@
             const elm = document.getElementById('testMainPushStateEcho');
 
             const originalPushState = history.pushState.bind(history);
+
             history.pushState = function(state, _, url) {
+              console.log('[debug]', state, _, url);
               originalPushState(state, _, url);
               elm.textContent = JSON.stringify({ state, url });
             }
@@ -237,6 +239,7 @@
           (function () {
             const buttonMainPushState = document.getElementById('buttonMainPushState');
             buttonMainPushState.addEventListener('click', () => {
+              console.log('[debug] history pushState =', history.pushState)
               history.pushState(42, '', '/tests/platform/history/pushed-state');
             });
           })();


### PR DESCRIPTION
Hey I was investigating issue with GTM inside next.js app. I noticed that tag manager assigns custom pushState/replaceState to forward history changes on SPA. However, Partytown never forwards those calls to worker.

An issue describing this problem was already reported here: https://github.com/BuilderIO/partytown/issues/165

This MR fixes the problem.