### PR TITLE
Issue-37 - createEnvironment in createHTMLDocument

### DIFF
--- a/src/lib/web-worker/worker-document.ts
+++ b/src/lib/web-worker/worker-document.ts
@@ -178,11 +178,12 @@ export const patchDocument = (
             callMethod(this, ['implementation', 'createHTMLDocument'], [title], CallType.Blocking, {
               $winId$,
             });
-            const docEnv = createWindow(
-              $winId$,
-              $winId$,
-              env.$location$ + '',
-              'hidden',
+            const docEnv = createEnvironment({
+                $winId$,
+                $parentWinId$: $winId$,
+                $url$: env.$location$ + '',
+                $visibilityState$: 'hidden',
+              },
               true,
               true
             );

--- a/src/lib/web-worker/worker-environment.ts
+++ b/src/lib/web-worker/worker-environment.ts
@@ -6,7 +6,7 @@ import { logWorker, normalizedWinId } from '../log';
 
 export const createEnvironment = (
   { $winId$, $parentWinId$, $url$, $visibilityState$ }: InitializeEnvironmentData,
-  isIframeWindow?: boolean
+  isIframeWindow?: boolean, isDocumentImplementation?: boolean
 ) => {
   if (!environments[$winId$]) {
     // create a simulated global environment for this window
@@ -16,7 +16,8 @@ export const createEnvironment = (
       $parentWinId$,
       $url$,
       $visibilityState$,
-      isIframeWindow
+      isIframeWindow,
+      isDocumentImplementation
     );
 
     if (debug) {

--- a/tests/platform/document/document.spec.ts
+++ b/tests/platform/document/document.spec.ts
@@ -92,7 +92,7 @@ test('document', async ({ page }) => {
   await expect(testCreateElementError_).toHaveText('no error');
 
   const testCreateHTMLDocument = page.locator('#testCreateHTMLDocument');
-  await expect(testCreateHTMLDocument).toHaveText('88mph hidden');
+  await expect(testCreateHTMLDocument).toHaveText('88mph hidden object');
 
   const testVisibilityState = page.locator('#testVisibilityState');
   await expect(testVisibilityState).toHaveText('visible');

--- a/tests/platform/document/index.html
+++ b/tests/platform/document/index.html
@@ -432,9 +432,13 @@
         <script type="text/partytown">
           (function () {
             const doc = document.implementation.createHTMLDocument();
-            doc.body.textContent = '88mph ' + doc.visibilityState;
 
             const elm = document.getElementById('testCreateHTMLDocument');
+
+            const addlElm = doc.createElement('base');
+            const addlElmType = typeof addlElm;
+
+            doc.body.textContent = '88mph ' + doc.visibilityState + ' ' + addlElmType;
             elm.textContent = doc.body.textContent;
           })();
         </script>


### PR DESCRIPTION
This seems to resolve the issue by ensuring the window object created in `WorkerDocument.implementation.createHTMLDocument` is registered with the `environments` so that subsequent calls to `createElement` on the document it returns are properly found by `getOrCreateNodeInstance`.

I've also updated the unit tests. Note these tests fail on the current `main` branch.