### PR TITLE
Include third-party cookies when fetching images

### DIFF
--- a/src/lib/web-worker/worker-image.ts
+++ b/src/lib/web-worker/worker-image.ts
@@ -24,6 +24,8 @@ export const createImageConstructor = (env: WebWorkerEnvironment) =>
         logWorker(`Image() request: ${resolveUrl(env, src)}`, env.$winId$);
       }
 
+      this.s = src;
+
       fetch(resolveUrl(env, src, true), {
         mode: 'no-cors',
         credentials: 'include',

--- a/src/lib/web-worker/worker-image.ts
+++ b/src/lib/web-worker/worker-image.ts
@@ -26,6 +26,7 @@ export const createImageConstructor = (env: WebWorkerEnvironment) =>
 
       fetch(resolveUrl(env, src, true), {
         mode: 'no-cors',
+        credentials: 'include',
         keepalive: true,
       }).then(
         (rsp) => {

--- a/tests/platform/image/image.spec.ts
+++ b/tests/platform/image/image.spec.ts
@@ -34,4 +34,8 @@ test('image', async ({ page }) => {
   await page.waitForSelector('.testImgListenerError');
   const testImgListenerError = page.locator('#testImgListenerError');
   await expect(testImgListenerError).toHaveText('error');
+
+  await page.waitForSelector('.testImgSrc');
+  const testImgSrc = page.locator('#testImgSrc');
+  await expect(testImgSrc).toHaveText('dot.gif?imageSrcTest');
 });

--- a/tests/platform/image/index.html
+++ b/tests/platform/image/index.html
@@ -183,6 +183,22 @@
           })();
         </script>
       </li>
+
+      <li>
+        <strong>&lt;img&gt; src</strong>
+        <code id="testImgSrc"></code>
+        <script type="text/partytown">
+          (function () {
+            const image = new Image();
+            image.src = 'dot.gif?imageSrcTest';
+            image.onload = function (ev) {
+              const elm = document.getElementById('testImgSrc');
+              elm.textContent = image.src;
+              elm.className = 'testImgSrc';
+            };
+          })();
+        </script>
+      </li>
     </ul>
 
     <hr />


### PR DESCRIPTION
I noticed that Partytown does not attach third-party cookies when fetching images. This breaks facebook pixel - take a look at the screen recording below.

On the left I have Facebook's 'Test events' tool. On the right NextJS app with Facebook Pixel added through GTM running within Partytown 😅 

https://user-images.githubusercontent.com/381865/169493259-26399c43-1c6c-45d5-ba3f-b8068c3881da.mp4

In addition to missing `credentials: 'include'`, I noticed that Image constructor never sets `src` attribute, I fixed it.