### PR TITLE
Add support for passing functions in `mainWindowAccessors`

### DIFF
--- a/src/lib/web-worker/worker-serialization.ts
+++ b/src/lib/web-worker/worker-serialization.ts
@@ -1,5 +1,6 @@
 import {
   ApplyPath,
+  CallType,
   InstanceId,
   RefHandlerCallbackData,
   RefId,
@@ -145,6 +146,12 @@ export const deserializeFromMain = (
     }
 
     if (serializedType === SerializedType.Function) {
+      if (winId) {
+        const env = environments[winId];
+
+        return (...args: any[]) => callMethod(env.$window$, applyPath, args, CallType.Blocking);
+      }
+
       return noop;
     }
 

--- a/src/lib/web-worker/worker-serialization.ts
+++ b/src/lib/web-worker/worker-serialization.ts
@@ -146,10 +146,8 @@ export const deserializeFromMain = (
     }
 
     if (serializedType === SerializedType.Function) {
-      if (winId) {
-        const env = environments[winId];
-
-        return (...args: any[]) => callMethod(env.$window$, applyPath, args, CallType.Blocking);
+      if (winId && applyPath.length > 0) {
+        return (...args: any[]) => callMethod(environments[winId].$window$, applyPath, args, CallType.Blocking);
       }
 
       return noop;

--- a/tests/integrations/main-window-accessors/index.html
+++ b/tests/integrations/main-window-accessors/index.html
@@ -13,7 +13,7 @@
       logSetters: true,
       logStackTraces: false,
       logScriptExecution: true,
-      mainWindowAccessors: ['globalField'],
+      mainWindowAccessors: ['globalField', 'globalFunction'],
     };
   </script>
   <script src='/~partytown/debug/partytown.js'></script>
@@ -88,6 +88,15 @@
     <code id='testChildWindowAccessor'></code>
     <script type='text/partytown'>
       document.getElementById('testChildWindowAccessor').innerText = window.globalField.parentObj.childValue;
+    </script>
+    <code id='testGlobalFunction'></code>
+    <script type='text/javascript'>
+      window.globalFunction = (arg) => {
+        document.getElementById('testGlobalFunction').textContent = JSON.stringify(arg);
+      }
+    </script>
+    <script type='text/partytown'>
+      window.globalFunction({ hello: 'world' });
     </script>
   </li>
   <script type='text/partytown'>

--- a/tests/integrations/main-window-accessors/main-window-accessors.spec.ts
+++ b/tests/integrations/main-window-accessors/main-window-accessors.spec.ts
@@ -9,4 +9,7 @@ test('integration window accessor', async ({ page }) => {
 
   const child_element = page.locator('#testChildWindowAccessor');
   await expect(child_element).toHaveText('stringValue');
+
+  const global_function = page.locator('#testGlobalFunction');
+  await expect(global_function).toHaveText('{"hello":"world"}');
 });


### PR DESCRIPTION
I recently stumbled upon `mainWindowAccessors`. I thought it would be cool if this could forward function calls too.

The implementation appeared to be relatively easy - I just added `callMethod` inside `worker-serialization.ts`. I didn't find any downsides of my change yet, but I would like to see another opinion.

This change along with my other PR (https://github.com/BuilderIO/partytown/pull/172) allowed me to integrate GTM Tag Assistant with Partytown inside Next.js app (https://github.com/BuilderIO/partytown/issues/72).

https://user-images.githubusercontent.com/381865/169507409-3de028e4-cb19-4093-96d2-55a85a275faf.mp4

What you see on the video above is Tag Assistant communicating with GTM running inside Partytown. It requires Tag Assistant Companion browser plugin. Change in Partytown is not enough to get this working. It also requires GTM-specific code that tunnels messages from worker back to the Tag Assistant Companion.