### PR TITLE
fix: anchor property setter

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -128,3 +128,12 @@ export const createElementFromConstructor = (
       : doc.createElement(htmlConstructorTags[tag] || tag);
   }
 };
+
+export const isValidUrl = (url: any): boolean => {
+  try {
+    new URL(url);
+    return true;
+  } catch (_) {
+    return false;
+  }
+}

--- a/src/lib/web-worker/worker-anchor.ts
+++ b/src/lib/web-worker/worker-anchor.ts
@@ -27,11 +27,13 @@ export const patchHTMLAnchorElement = (WorkerHTMLAnchorElement: any, env: WebWor
         let url;
 
         if (anchorProp === 'href') {
-          const baseHref = isValidUrl(value)
-              ? new URL(value).href
-              : env.$location$.href
-          url = resolveToUrl(env, baseHref);
-          url.href = new URL(value + '', url.href);
+          if (isValidUrl(value)) {
+            url = new URL(value);
+          } else {
+            const baseHref = env.$location$.href
+            url = resolveToUrl(env, baseHref);
+            url.href = new URL(value + '', url.href);
+          }
         } else {
           url = resolveToUrl(env, this.href);
           url[anchorProp] = value;

--- a/tests/platform/anchor/anchor.spec.ts
+++ b/tests/platform/anchor/anchor.spec.ts
@@ -30,4 +30,22 @@ test('anchor', async ({ page }) => {
   await page.waitForSelector('.testSetHref');
   const testSetHref = page.locator('#testSetHref');
   await expect(testSetHref).toHaveText('/pathname');
+
+  await page.waitForSelector('.testSetHref2');
+  const testSetHref2 = page.locator('#testSetHref2');
+  const desiredLocalUrl = new URL(page.url());
+  desiredLocalUrl.pathname = '/local-pathname'
+  await expect(testSetHref2).toHaveText(desiredLocalUrl.toString());
+
+  await page.waitForSelector('.testGetSearch');
+  const testGetSearch = page.locator('#testGetSearch');
+  await expect(testGetSearch).toHaveText('?a=42&b=23');
+  const testGetSearchHref = page.locator('#testGetSearchHref');
+  await expect(testGetSearchHref).toHaveText('https://builder.io/?a=42&b=23');
+
+  await page.waitForSelector('.testSetSearch');
+  const testSetSearch = page.locator('#testSetSearch');
+  await expect(testSetSearch).toHaveText('?x=1&y=2');
+  const testSetSearchHref = page.locator('#testSetSearchHref');
+  await expect(testSetSearchHref).toHaveText('https://builder.io/?x=1&y=2');
 });

--- a/tests/platform/anchor/index.html
+++ b/tests/platform/anchor/index.html
@@ -75,7 +75,7 @@
           })();
         </script>
       </li>
-      
+
       <li>
         <strong>constructor.name</strong>
         <div><a id="testAnchorConstructor"></a></div>
@@ -90,7 +90,7 @@
 
       <li>
         <strong>createElement('a'), no appendChild</strong>
-        <div id="testCreateAnchorNoAppend"></a>
+        <div id="testCreateAnchorNoAppend"></div>
         <script type="text/partytown">
           (function () {
             const a = document.createElement('a');
@@ -136,7 +136,7 @@
             elm.className = 'testInnerHtmlFirstChild';
           })();
         </script>
-      </li> 
+      </li>
 
       <li>
         <strong>get <a id="getHref" href="https://builder.io/">href</a></strong>
@@ -161,6 +161,62 @@
             const elm = document.getElementById('testSetHref');
             elm.textContent = a.pathname;
             elm.className = 'testSetHref';
+          })();
+        </script>
+      </li>
+
+      <li>
+        <strong>set <a id="setHref2" href="/">href</a> 2</strong>
+        <div id="testSetHref2"></div>
+        <script type="text/partytown">
+          (function () {
+            const a = document.getElementById('setHref');
+            a.href = 'http://builder.io/pathname';
+            a.href = '/local-pathname';
+            const elm = document.getElementById('testSetHref2');
+            elm.textContent = a.href;
+            elm.className = 'testSetHref2';
+          })();
+        </script>
+      </li>
+
+      <li>
+        <strong>get <a id="getSearch" href="https://builder.io/?a=42&b=23">search</a></strong>
+        <div>
+          <strong>search:</strong><span id="testGetSearch"></span>
+          <strong>href:</strong><span id="testGetSearchHref"></span>
+        </div>
+        <script type="text/partytown">
+          (function () {
+            const a = document.getElementById('getSearch');
+
+            const elmHref = document.getElementById('testGetSearchHref');
+            elmHref.textContent = a.href;
+
+            const elm = document.getElementById('testGetSearch');
+            elm.textContent = a.search;
+            elm.className = 'testGetSearch';
+          })();
+        </script>
+      </li>
+
+      <li>
+        <strong>set <a id="setSearch" href="https://builder.io/?a=42&b=23">search</a></strong>
+        <div>
+          <strong>search:</strong><span id="testSetSearch"></span>
+          <strong>href:</strong><span id="testSetSearchHref"></span>
+        </div>
+        <script type="text/partytown">
+          (function () {
+            const a = document.getElementById('setSearch');
+            a.search = '?x=1&y=2';
+
+            const elmHref = document.getElementById('testSetSearchHref');
+            elmHref.textContent = a.href;
+
+            const elm = document.getElementById('testSetSearch');
+            elm.textContent = a.search;
+            elm.className = 'testSetSearch';
           })();
         </script>
       </li>


### PR DESCRIPTION
I noticed that with current implementation of anchor property setter doesn't really work with properties other than `href`. Run this code inside Partytown to see what I'm talking about:

```js
a = document.createElement('a');
a.href = 'https://partytown.builder.io/?foo=bar'
a.search = '?x=y';
console.log(a.href);
// logs: https://partytown.builder.io/?https://partytown.builder.io/?x=y
// should be: https://partytown.builder.io/?x=y

a = document.createElement('a');
a.href = 'https://partytown.builder.io/?foo=bar'
a.host = 'foo.bar';
console.log(a.href);
// logs: https://https/?foo=bar
// should be: https://foo.bar/?foo=bar
```

This PR reimplements the setter.