### PR TITLE
fix: update location before calling pushState handlers

### DIFF
--- a/src/lib/web-worker/index.ts
+++ b/src/lib/web-worker/index.ts
@@ -44,9 +44,9 @@ const receiveMessageFromSandboxToWorker = (ev: MessageEvent<MessageFromSandboxTo
       const $winId$ = msgValue.$winId$;
       const env = environments[$winId$];
 
-      forwardLocationChange(msgValue.$winId$, env, msgValue);
-
       env.$location$.href = msgValue.url;
+
+      forwardLocationChange(msgValue.$winId$, env, msgValue);
     } else if (msgType === WorkerMessageType.CustomElementCallback) {
       callCustomElementCallback(...msg);
     }


### PR DESCRIPTION
I found a bug in the way pushState is propagated inside worker - it's called with previous location.