### PR TITLE
fix: do not resolve anchor, add type to resolveUrl

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -83,12 +83,12 @@ export const enum LocationUpdateType {
   PushState,
   ReplaceState,
   PopState,
-  HashChange
+  HashChange,
 }
 
 export interface LocationUpdateData {
   $winId$: WinId;
-  type: LocationUpdateType,
+  type: LocationUpdateType;
   state: object;
   url: string;
   newUrl?: string;
@@ -303,10 +303,7 @@ export type SerializedCSSStyleDeclarationTransfer = [
   { [key: string]: SerializedTransfer | undefined }
 ];
 
-export type SerializedErrorTransfer = [
-  SerializedType.Error,
-  Error
-];
+export type SerializedErrorTransfer = [SerializedType.Error, Error];
 
 export type SerializedEventTransfer = [SerializedType.Event, SerializedObject];
 
@@ -374,6 +371,8 @@ export type SerializedInstance =
       type: string
     ];
 
+export type ResolveUrlType = 'fetch' | 'xhr' | 'script' | 'iframe';
+
 /**
  * https://partytown.builder.io/configuration
  *
@@ -388,9 +387,10 @@ export interface PartytownConfig {
    *
    * @param url - The URL to be resolved. This is a URL https://developer.mozilla.org/en-US/docs/Web/API/URL, not a string.
    * @param location - The current window location.
+   * @param type - The type of resource the url is being resolved for. For example, `fetch` is the value when resolving for `fetch()`, and `a` would be the value when resolving for an anchor element's `href`.
    * @returns The returned value must be a URL interface, otherwise the default resolved URL is used.
    */
-  resolveUrl?(url: URL, location: Location): URL | undefined | null;
+  resolveUrl?(url: URL, location: Location, type: ResolveUrlType): URL | undefined | null;
   /**
    * When set to `true`, Partytown scripts are not inlined and not minified.
    *

--- a/src/lib/web-worker/worker-anchor.ts
+++ b/src/lib/web-worker/worker-anchor.ts
@@ -20,7 +20,7 @@ export const patchHTMLAnchorElement = (WorkerHTMLAnchorElement: any, env: WebWor
           value = (new URL(href) as any)[anchorProp];
         }
 
-        return (resolveToUrl(env, value) as any)[anchorProp];
+        return (resolveToUrl(env, value, null) as any)[anchorProp];
       },
 
       set(this: any, value) {
@@ -30,12 +30,12 @@ export const patchHTMLAnchorElement = (WorkerHTMLAnchorElement: any, env: WebWor
           if (isValidUrl(value)) {
             url = new URL(value);
           } else {
-            const baseHref = env.$location$.href
-            url = resolveToUrl(env, baseHref);
+            const baseHref = env.$location$.href;
+            url = resolveToUrl(env, baseHref, null);
             url.href = new URL(value + '', url.href);
           }
         } else {
-          url = resolveToUrl(env, this.href);
+          url = resolveToUrl(env, this.href, null);
           url[anchorProp] = value;
         }
 

--- a/src/lib/web-worker/worker-exec.ts
+++ b/src/lib/web-worker/worker-exec.ts
@@ -5,6 +5,7 @@ import {
   InitializeScriptData,
   InstanceId,
   NodeName,
+  ResolveUrlType,
   StateProp,
   WebWorkerEnvironment,
   WinId,
@@ -29,7 +30,7 @@ export const initNextScriptsInWebWorker = async (initScript: InitializeScriptDat
 
   if (scriptSrc) {
     try {
-      scriptSrc = resolveToUrl(env, scriptSrc) + '';
+      scriptSrc = resolveToUrl(env, scriptSrc, 'script') + '';
 
       setInstanceStateValue(instance!, StateProp.url, scriptSrc);
 
@@ -169,7 +170,7 @@ export const insertIframe = (winId: WinId, iframe: WorkerInstance) => {
 export const resolveToUrl = (
   env: WebWorkerEnvironment,
   url: string,
-  noUserHook?: boolean,
+  type: ResolveUrlType | null,
   baseLocation?: Location,
   resolvedUrl?: URL,
   configResolvedUrl?: any
@@ -184,8 +185,8 @@ export const resolveToUrl = (
   }
 
   resolvedUrl = new URL(url || '', baseLocation as any);
-  if (!noUserHook && webWorkerCtx.$config$.resolveUrl) {
-    configResolvedUrl = webWorkerCtx.$config$.resolveUrl!(resolvedUrl, baseLocation);
+  if (type && webWorkerCtx.$config$.resolveUrl) {
+    configResolvedUrl = webWorkerCtx.$config$.resolveUrl!(resolvedUrl, baseLocation, type!);
     if (configResolvedUrl) {
       return configResolvedUrl;
     }
@@ -193,8 +194,8 @@ export const resolveToUrl = (
   return resolvedUrl;
 };
 
-export const resolveUrl = (env: WebWorkerEnvironment, url: string, noUserHook?: boolean) =>
-  resolveToUrl(env, url, noUserHook) + '';
+export const resolveUrl = (env: WebWorkerEnvironment, url: string, type: ResolveUrlType | null) =>
+  resolveToUrl(env, url, type) + '';
 
 export const getPartytownScript = () =>
   `<script src="${partytownLibUrl('partytown.js?v=' + VERSION)}"></script>`;

--- a/src/lib/web-worker/worker-iframe.ts
+++ b/src/lib/web-worker/worker-iframe.ts
@@ -55,7 +55,7 @@ export const patchHTMLIFrameElement = (WorkerHTMLIFrameElement: any, env: WebWor
           let xhrStatus: number;
           let env = getIframeEnv(this);
 
-          env.$location$.href = src = resolveUrl(env, src);
+          env.$location$.href = src = resolveUrl(env, src, 'iframe');
           env.$isLoading$ = 1;
 
           setInstanceStateValue(this, StateProp.loadErrorStatus, undefined);

--- a/src/lib/web-worker/worker-image.ts
+++ b/src/lib/web-worker/worker-image.ts
@@ -21,12 +21,12 @@ export const createImageConstructor = (env: WebWorkerEnvironment) =>
     }
     set src(src: string) {
       if (debug && webWorkerCtx.$config$.logImageRequests) {
-        logWorker(`Image() request: ${resolveUrl(env, src)}`, env.$winId$);
+        logWorker(`Image() request: ${resolveUrl(env, src, null)}`, env.$winId$);
       }
 
       this.s = src;
 
-      fetch(resolveUrl(env, src, true), {
+      fetch(resolveUrl(env, src, null), {
         mode: 'no-cors',
         credentials: 'include',
         keepalive: true,

--- a/src/lib/web-worker/worker-navigator.ts
+++ b/src/lib/web-worker/worker-navigator.ts
@@ -11,7 +11,7 @@ export const createNavigator = (env: WebWorkerEnvironment) => {
       if (debug && webWorkerCtx.$config$.logSendBeaconRequests) {
         try {
           logWorker(
-            `sendBeacon: ${resolveUrl(env, url, true)}${
+            `sendBeacon: ${resolveUrl(env, url, null)}${
               body ? ', data: ' + JSON.stringify(body) : ''
             }`
           );
@@ -20,7 +20,7 @@ export const createNavigator = (env: WebWorkerEnvironment) => {
         }
       }
       try {
-        fetch(resolveUrl(env, url, true), {
+        fetch(resolveUrl(env, url, null), {
           method: 'POST',
           body,
           mode: 'no-cors',

--- a/src/lib/web-worker/worker-script.ts
+++ b/src/lib/web-worker/worker-script.ts
@@ -15,8 +15,8 @@ export const patchHTMLScriptElement = (WorkerHTMLScriptElement: any, env: WebWor
         return getInstanceStateValue<string>(this, StateProp.url) || '';
       },
       set(url: string) {
-        const orgUrl = resolveUrl(env, url, true);
-        url = resolveUrl(env, url);
+        const orgUrl = resolveUrl(env, url, null);
+        url = resolveUrl(env, url, 'script');
         setInstanceStateValue(this, StateProp.url, url);
         setter(this, ['src'], url);
         if (orgUrl !== url) {

--- a/src/lib/web-worker/worker-window.ts
+++ b/src/lib/web-worker/worker-window.ts
@@ -435,19 +435,22 @@ export const createWindow = (
           };
           win.indexeddb = undefined;
         } else {
-          const originalPushState: Window['history']['pushState'] = win.history.pushState.bind(win.history);
-          const originalReplaceState: Window['history']['replaceState'] = win.history.replaceState.bind(win.history);
+          const originalPushState: Window['history']['pushState'] = win.history.pushState.bind(
+            win.history
+          );
+          const originalReplaceState: Window['history']['replaceState'] =
+            win.history.replaceState.bind(win.history);
 
           win.history.pushState = (stateObj: any, _: string, newUrl?: string) => {
             if (env.$propagateHistoryChange$ !== false) {
-              originalPushState(stateObj, _, newUrl)
+              originalPushState(stateObj, _, newUrl);
             }
-          }
+          };
           win.history.replaceState = (stateObj: any, _: string, newUrl?: string) => {
             if (env.$propagateHistoryChange$ !== false) {
-              originalReplaceState(stateObj, _, newUrl)
+              originalReplaceState(stateObj, _, newUrl);
             }
-          }
+          };
         }
 
         win.Worker = undefined;
@@ -477,7 +480,7 @@ export const createWindow = (
 
       fetch(input: string | URL | Request, init: any) {
         input = typeof input === 'string' || input instanceof URL ? String(input) : input.url;
-        return fetch(resolveUrl(env, input), init);
+        return fetch(resolveUrl(env, input, 'fetch'), init);
       }
 
       get frames() {
@@ -576,7 +579,7 @@ export const createWindow = (
         const ExtendedXhr = defineConstructorName(
           class extends Xhr {
             open(...args: any[]) {
-              args[1] = resolveUrl(env, args[1]);
+              args[1] = resolveUrl(env, args[1], 'xhr');
               (super.open as any)(...args);
             }
             set withCredentials(_: any) {}


### PR DESCRIPTION
Previously `<a href>` urls were resolved by a user's `resolveUrl()` config. This change will no longer have an anchor element's href resolved with the user config.

Additionally, all calls to a user's `resolveUrl()` will now include a third argument of the resource type, such as `fetch`, `xhr` or `script`.

```
resolveUrl(url: URL, location: Location, type: ResolveUrlType): URL | undefined | null;
```