### PR TITLE
Enable to push back 'forwarded' Array values on main thread

### DIFF
--- a/src/lib/sandbox/main-forward-trigger.ts
+++ b/src/lib/sandbox/main-forward-trigger.ts
@@ -5,10 +5,14 @@ import { serializeForWorker } from './main-serialization';
 export const mainForwardTrigger = (worker: PartytownWebWorker, $winId$: WinId, win: MainWindow) => {
   let queuedForwardCalls = win._ptf;
   let forwards = (win.partytown || {}).forward || [];
+  let pushBacks = (win.partytown || {}).pushBack || [];
   let i: number;
   let mainForwardFn: any;
 
-  let forwardCall = ($forward$: string[], args: any) =>
+  let forwardCall = ($forward$: string[], args: any) => {
+    // Allow to push data back to window object, according to config
+    pushBackData($forward$, args)
+
     worker.postMessage([
       WorkerMessageType.ForwardMainTrigger,
       {
@@ -17,6 +21,19 @@ export const mainForwardTrigger = (worker: PartytownWebWorker, $winId$: WinId, w
         $args$: serializeForWorker($winId$, Array.from(args)),
       },
     ]);
+  }
+
+  // Read config and execute a splice instead of the push method on the given global object
+  const pushBackData = (forwardArr: string[], args: any) => {
+    if (pushBacks.length > 0 && pushBacks.includes(forwardArr.join('.'))) {
+      if (forwardArr.length === 2 && forwardArr[1] === 'push') {
+        win[forwardArr[0]] = win[forwardArr[0]] || [];
+        win[forwardArr[0]].splice(win[forwardArr[0]].length, 0, ...args);
+      } else {
+        console.warn(`Error with 'pushBack' config`);
+      }
+    }
+  }
 
   win._ptf = undefined;
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -415,6 +415,20 @@ export interface PartytownConfig {
    * https://partytown.builder.io/forwarding-events
    */
   forward?: PartytownForwardProperty[];
+
+  /**
+   * Some scripts that runs on the main thread may want to access data on global window object.
+   * If a data as been forwarded with a `push`, as defined in the `forward` config, this `pushBack` config
+   * allow to get the data back to the global window scope, using the `Array.splice` method.
+   * NOTE: only handle a depth of 1 (ie "object.sub.push" will fail)
+   * Example with Google Tag Manager:
+   *
+   * ```js
+   * ['dataLayer.push']
+   * ```
+   */
+  pushBack?: PartytownPushBackProperty[];
+
   mainWindowAccessors?: string[];
   /**
    * Rarely, a script will add a named function to the global scope with the
@@ -485,6 +499,13 @@ export interface PartytownConfig {
 export type PartytownForwardProperty = string;
 
 /**
+ * Represent the object and its method that should be re-applied on the main thread.
+ * As an example, `dataLayer.push` will set a 'dataLayer' var on the main window and replay the 'push'es on it
+ * @public
+ */
+export type PartytownPushBackProperty = string;
+
+/**
  * @public
  */
 export type GetHook = (opts: GetHookOptions) => any;
@@ -529,6 +550,8 @@ export interface ApplyHookOptions extends HookOptions {
 export interface MainWindow extends Window {
   partytown?: PartytownConfig;
   _ptf?: any[];
+  // handle `dataLayer` and others third-party global variables
+  [key: string]: any;
 }
 
 export const enum NodeName {


### PR DESCRIPTION
Hi,

This PR solve my case where some scripts running on the main thread needs to read the data that have been pushed inside the "dataLayer" array.

I've added this behavior in the mainForwardTrigger, but that might not be the best place to set this.

Thank you for your feedback, and happy to improve it :)