### PR TITLE
Added support for document.images

### DIFF
--- a/src/lib/web-worker/worker-document.ts
+++ b/src/lib/web-worker/worker-document.ts
@@ -169,6 +169,12 @@ export const patchDocument = (
       },
     },
 
+    images: {
+      get() {
+        return getter(this, ['images']);
+      },
+    },
+
     implementation: {
       get() {
         return {

--- a/tests/platform/document/document.spec.ts
+++ b/tests/platform/document/document.spec.ts
@@ -96,4 +96,8 @@ test('document', async ({ page }) => {
 
   const testVisibilityState = page.locator('#testVisibilityState');
   await expect(testVisibilityState).toHaveText('visible');
+
+  const testImages = page.locator('#testDocumentImages');
+  const pageUrl = new URL(page.url());
+  await expect(testImages).toHaveText(`${pageUrl.origin}/fake.jpg`);
 });

--- a/tests/platform/document/index.html
+++ b/tests/platform/document/index.html
@@ -452,6 +452,18 @@
         </script>
       </li>
 
+      <li>
+        <strong>document.images</strong>
+        <code id="testDocumentImages"></code>
+        <img src="/fake.jpg" />
+        <script type="text/partytown">
+          (function () {
+            const elm = document.getElementById('testDocumentImages');
+            elm.textContent = document.images[0].src;
+          })();
+        </script>
+      </li>
+
       <script type="text/partytown">
         (function () {
           document.body.classList.add('completed');


### PR DESCRIPTION
I've got a script I'd like to run from Partytown that accesses `document.images` which currently returns `undefined` instead of the proper `HTMLCollection`. I've added support for `document.images` (following the implementation of `document.cookies` as an example). Happy to tweak this if this isn't quite right.