### PR TITLE
fix: update worker-script innerHTML implementation

### DIFF
--- a/tests/platform/script/index.html
+++ b/tests/platform/script/index.html
@@ -244,6 +244,24 @@
       </li>
 
       <li>
+        <strong>set innerHTML, nested</strong>
+        <code some-attr="111" id="testInnerHTMLNested"></code>
+        <script type="text/partytown">
+          (function () {
+            const testEl = document.getElementById('testInnerHTMLNested');
+            const parent = document.createElement('div');
+            parent.innerHTML = '<script>console.log(42);<\/script>';
+
+            testEl.innerHTML = [
+              parent.firstChild.tagName,
+              parent.firstChild.innerHTML
+            ].join(', ');
+            testEl.className = 'testInnerHTMLNested';
+          })();
+        </script>
+      </li>
+
+      <li>
         <strong>async/defer</strong>
         <code id="testAsync"></code>
         <script src="defer-1.js" defer type="text/partytown"></script>

--- a/tests/platform/script/script.spec.ts
+++ b/tests/platform/script/script.spec.ts
@@ -41,6 +41,10 @@ test('script', async ({ page }) => {
   const testInnerHTMLError = page.locator('#testInnerHTMLError');
   await expect(testInnerHTMLError).toHaveText('gahh');
 
+  await page.waitForSelector('.testInnerHTMLNested');
+  const testInnerHTMLNested = page.locator('#testInnerHTMLNested');
+  await expect(testInnerHTMLNested).toHaveText('SCRIPT, console.log(42);');
+
   await page.waitForSelector('.testAsync');
   const testAsync = page.locator('#testAsync');
   const testAsyncText = await testAsync.innerText();


### PR DESCRIPTION
I noticed that setting innerHTML does not work as expected for nested script tags.

Take a look at this code:
```
div = document.createElement('div');
div.innerHTML = '<script>console.log(42);</script>';
console.log(div.firstChild.innerHTML);
```
It should log the content of the script. Unfortunately when run inside Partytown it returns empty string.

In addition to the above, I added descriptor for `text` property, via https://developer.mozilla.org/en-US/docs/Web/API/HTMLScriptElement:
> HTMLScriptElement.text
> A string that joins and returns the contents of all [Text nodes](https://developer.mozilla.org/en-US/docs/Web/API/Text) inside the [<script>](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script) element (ignoring other nodes like comments) in tree order. On setting, it acts the same way as the [textContent](https://developer.mozilla.org/en-US/docs/Web/API/Node/textContent) IDL attribute.