### PR TITLE
fix: expose global functions when they are wrapped with try/catch

### DIFF
--- a/src/lib/web-worker/worker-exec.ts
+++ b/src/lib/web-worker/worker-exec.ts
@@ -106,12 +106,13 @@ export const run = (env: WebWorkerEnvironment, scriptContent: string, scriptUrl?
 
   scriptContent =
     `with(this){${
+      scriptContent.replace(/\bthis\b/g, '(thi$(this)?window:this)').replace(/\/\/# so/g, '//Xso')
+    }\n;function thi$(t){return t===this}};${
       (webWorkerCtx.$config$.globalFns || [])
         .filter((globalFnName) => /[a-zA-Z_$][0-9a-zA-Z_$]*/.test(globalFnName))
-        .map((g) => `(typeof ${g}=='function'&&(window.${g}=${g}))`)
-        .join(';') +
-      scriptContent.replace(/\bthis\b/g, '(thi$(this)?window:this)').replace(/\/\/# so/g, '//Xso')
-    }\n;function thi$(t){return t===this}}` + (scriptUrl ? '\n//# sourceURL=' + scriptUrl : '');
+        .map((g) => `(typeof ${g}=='function'&&(this.${g}=${g}))`)
+        .join(';')
+    };` + (scriptUrl ? '\n//# sourceURL=' + scriptUrl : '');
 
   if (!env.$isSameOrigin$) {
     scriptContent = scriptContent.replace(/.postMessage\(/g, `.postMessage('${env.$winId$}',`);

--- a/tests/unit/worker-exec.spec.ts
+++ b/tests/unit/worker-exec.spec.ts
@@ -45,16 +45,39 @@ test('Class this', ({ env, win }) => {
 
 test('manually define global functions', ({ env, win, config }) => {
   config.globalFns = ['abc', 'xyz'];
-  const s = `
+  const s1 = `
     function abc() {
       return true;
     }
     function xyz() {
       return true;
     }
+  `;
+  const s2 = `
     window.result = window.abc() && window.xyz();
   `;
-  run(env, s);
+  run(env, s1);
+  run(env, s2);
+  assert.is(win.result, true);
+});
+
+test('manually define global functions in try/catch', ({ env, win, config }) => {
+  config.globalFns = ['abc', 'xyz'];
+  const s1 = `
+    try {
+      function abc() {
+        return true;
+      }
+      function xyz() {
+        return true;
+      }
+    } catch(err) {}
+  `;
+  const s2 = `
+    window.result = window.abc() && window.xyz();
+  `;
+  run(env, s1);
+  run(env, s2);
   assert.is(win.result, true);
 });
 


### PR DESCRIPTION
This PR modifies the snippet used to wrap scripts with functions exposed via 'globalFns.' Previous implementations did not work properly when functions were declared within a 'try/catch' block, for example:
```html
<script type="text/partytown">
  try {
    function hello() {
      console.log('hello world!');
    }
  } catch (err) {}
</script>
<script type="text/partytown">
  if (hello) {
    hello();
  }
</script>
```