### PR TITLE
fix: exit early when both atomics and ServiceWorker are not supported

### DIFF
--- a/src/integration/snippet.ts
+++ b/src/integration/snippet.ts
@@ -15,6 +15,7 @@ export const createSnippet = (config: PartytownConfig | undefined | null, snippe
 
   return [
     `!(function(w,p,f,c){`,
+    `if(!window.crossOriginIsolated && !navigator.serviceWorker) return;`,
     Object.keys(filteredConfig).length > 0
       ? `c=w[p]=Object.assign(w[p]||{},${configStr});`
       : `c=w[p]=w[p]||{};`,


### PR DESCRIPTION
This PR fixes a bug that prevents some 3rd party scripts from loading in browsers that does not support service workers and atomics.

Partytown initializes all of the properties listed in the 'forwarded' array. However, at this point, it does not check to see if the browser supports the required features; this is done later. As a result, some third-party scripts may mistakenly perceive themselves as already loaded (for example FB pixel checks if the `fbq` property is present).

In my experience, the most common browser that does not support Partytown is... the iOS in-app browser! Users who click on Facebook ads see your website without Partytown loaded.