### PR TITLE
feat: Allow forward calls with return value

### DIFF
--- a/src/integration/snippet.ts
+++ b/src/integration/snippet.ts
@@ -1,7 +1,7 @@
 import type { PartytownConfig } from '../lib/types';
 
 export const createSnippet = (config: PartytownConfig | undefined | null, snippetCode: string) => {
-  const { forward = [], ...filteredConfig } = config || {};
+  const { forward = [], forwardCall = [], ...filteredConfig } = config || {};
 
   const configStr = JSON.stringify(filteredConfig, (k, v) => {
     if (typeof v === 'function') {
@@ -14,13 +14,15 @@ export const createSnippet = (config: PartytownConfig | undefined | null, snippe
   });
 
   return [
-    `!(function(w,p,f,c){`,
+    `!(function(w,p,f,fc,c){`,
     Object.keys(filteredConfig).length > 0
       ? `c=w[p]=Object.assign(w[p]||{},${configStr});`
       : `c=w[p]=w[p]||{};`,
     `c[f]=(c[f]||[])`,
-    forward.length > 0 ? `.concat(${JSON.stringify(forward)})` : ``,
-    `})(window,'partytown','forward');`,
+    forward.length > 0 ? `.concat(${JSON.stringify(forward)});` : `;`,
+    `c[fc]=(c[fc]||[])`,
+    forwardCall.length > 0 ? `.concat(${JSON.stringify(forwardCall)})` : ``,
+    `})(window,'partytown','forward','forwardCall');`,
     snippetCode,
   ].join('');
 };

--- a/src/lib/sandbox/main-forward-call.ts
+++ b/src/lib/sandbox/main-forward-call.ts
@@ -1,0 +1,50 @@
+import { forwardCallWrapper, len, randomId } from '../utils';
+import { MainWindow, PartytownWebWorker, WinId, WorkerMessageType } from '../types';
+import { serializeForWorker } from './main-serialization';
+
+export const mainForwardCall = (worker: PartytownWebWorker, $winId$: WinId, win: MainWindow) => {
+  const queuedForwardCalls = win._ptfc;
+  const forwards = (win.partytown || {}).forwardCall || [];
+  let i: number;
+  let mainForwardFn: any;
+
+  const forwardCall = ($forward$: string[], args: any, callId?: string) => {
+    const $callId$ = callId || randomId();
+
+    worker.postMessage([
+      WorkerMessageType.ForwardMainCall,
+      {
+        $winId$,
+        $forward$,
+        $callId$,
+        $args$: serializeForWorker($winId$, Array.from(args)),
+      },
+    ]);
+
+    return $callId$;
+  };
+
+  const forwardCallWithWrapper = ($forward$: string[], args: any, callId?: string) => {
+    const wrappedCallId = forwardCall($forward$, args, callId);
+
+    return forwardCallWrapper(wrappedCallId, win);
+  };
+
+  win._ptfc = undefined;
+
+  forwards.map((forwardProps) => {
+    mainForwardFn = win;
+    forwardProps.split('.').map((_, i, arr) => {
+      mainForwardFn = mainForwardFn[arr[i]] =
+        i + 1 < len(arr)
+          ? mainForwardFn[arr[i]] || (arr[i + 1] === 'push' ? [] : {})
+          : (...args: any) => forwardCallWithWrapper(arr, args);
+    });
+  });
+
+  if (queuedForwardCalls) {
+    for (i = 0; i < len(queuedForwardCalls); i += 3) {
+      forwardCall(queuedForwardCalls[i], queuedForwardCalls[i + 1], queuedForwardCalls[i + 2]);
+    }
+  }
+};

--- a/src/lib/sandbox/read-main-scripts.ts
+++ b/src/lib/sandbox/read-main-scripts.ts
@@ -7,6 +7,7 @@ import {
   PartytownWebWorker,
   WorkerMessageType,
 } from '../types';
+import { mainForwardCall } from './main-forward-call'
 import { mainForwardTrigger } from './main-forward-trigger';
 import { logMain, normalizedWinId } from '../log';
 
@@ -56,6 +57,7 @@ export const readNextScript = (worker: PartytownWebWorker, winCtx: MainWindowCon
         // finished environment initialization
         winCtx.$isInitialized$ = 1;
 
+        mainForwardCall(worker, $winId$, win);
         mainForwardTrigger(worker, $winId$, win);
 
         doc.dispatchEvent(new CustomEvent('pt0'));

--- a/src/lib/web-worker/index.ts
+++ b/src/lib/web-worker/index.ts
@@ -3,10 +3,11 @@ import { callWorkerRefHandler } from './worker-serialization';
 import { createEnvironment } from './worker-environment';
 import { debug } from '../utils';
 import { environments, webWorkerCtx } from './worker-constants';
-import { ForwardMainTriggerData, MessageFromSandboxToWorker, WorkerMessageType } from '../types';
+import { ForwardMainCallData, ForwardMainTriggerData, MessageFromSandboxToWorker, WorkerMessageType } from '../types';
 import { initNextScriptsInWebWorker } from './worker-exec';
 import { initWebWorker } from './init-web-worker';
 import { logWorker, normalizedWinId } from '../log';
+import { workerForwardedCallHandle } from './worker-forwarded-call';
 import { workerForwardedTriggerHandle } from './worker-forwarded-trigger';
 import { forwardLocationChange } from './worker-location';
 
@@ -24,6 +25,8 @@ const receiveMessageFromSandboxToWorker = (ev: MessageEvent<MessageFromSandboxTo
     } else if (msgType === WorkerMessageType.RefHandlerCallback) {
       // main has called a worker ref handler
       callWorkerRefHandler(msgValue);
+    } else if (msgType === WorkerMessageType.ForwardMainCall) {
+      workerForwardedCallHandle(msgValue as ForwardMainCallData);
     } else if (msgType === WorkerMessageType.ForwardMainTrigger) {
       workerForwardedTriggerHandle(msgValue as ForwardMainTriggerData);
     } else if (msgType === WorkerMessageType.InitializeEnvironment) {

--- a/src/lib/web-worker/worker-forwarded-call.ts
+++ b/src/lib/web-worker/worker-forwarded-call.ts
@@ -1,0 +1,38 @@
+import { deserializeFromMain } from './worker-serialization';
+import { environments } from './worker-constants';
+import type { ForwardMainCallData } from '../types';
+import { len } from '../utils';
+
+export const workerForwardedCallHandle = ({
+  $winId$,
+  $forward$,
+  $callId$,
+  $args$,
+}: ForwardMainCallData) => {
+  // see src/lib/main/snippet.ts and src/lib/sandbox/main-forward-call.ts
+  try {
+    const targetWindow = environments[$winId$].$window$
+
+    let target: any = environments[$winId$].$window$;
+    let i = 0;
+    const l = len($forward$);
+
+    for (; i < l; i++) {
+      if (i + 1 < l) {
+        target = target[$forward$[i]];
+      } else {
+        const $result$ = target[$forward$[i]].apply(
+          target,
+          deserializeFromMain(null, $winId$, [], $args$)
+        );
+
+        targetWindow.postMessage({
+          $callId$,
+          $result$,
+        });
+      }
+    }
+  } catch (e) {
+    console.error(e);
+  }
+};

--- a/tests/index.html
+++ b/tests/index.html
@@ -116,6 +116,7 @@
     <ul>
       <li><a href="/tests/integrations/clarity/">Clarity</a></li>
       <li><a href="/tests/integrations/config/">Config</a></li>
+      <li><a href="/tests/integrations/call-forwarding/">Call Forwarding</a></li>
       <li><a href="/tests/integrations/event-forwarding/">Event Forwarding</a></li>
       <li><a href="/tests/integrations/main-window-accessors/">Main Window Accessors</a></li>
       <li>

--- a/tests/integrations/call-forwarding/call-forwarding.spec.ts
+++ b/tests/integrations/call-forwarding/call-forwarding.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+test('integration call forwarding', async ({ page }) => {
+  await page.goto('/tests/integrations/call-forwarding/');
+  await page.waitForSelector('.completed');
+
+  const testStandardCallQueued = page.locator('#testStandardCallQueued');
+  const testNestedCallQueued = page.locator('#testNestedCallQueued');
+
+  await expect(testStandardCallQueued).toHaveText('16');
+  await expect(testNestedCallQueued).toHaveText('25');
+
+  const buttonStandardCall = page.locator('#buttonStandardCall');
+  const testStandardCall = page.locator('#testStandardCall');
+
+  await buttonStandardCall.click();
+  await expect(testStandardCall).toHaveText('0');
+  await buttonStandardCall.click();
+  await expect(testStandardCall).toHaveText('1');
+  await buttonStandardCall.click();
+  await expect(testStandardCall).toHaveText('4');
+
+  const buttonNestedCall = page.locator('#buttonNestedCall');
+  const testNestedCall = page.locator('#testNestedCall');
+
+  await buttonNestedCall.click();
+  await expect(testNestedCall).toHaveText('0');
+  await buttonNestedCall.click();
+  await expect(testNestedCall).toHaveText('1');
+  await buttonNestedCall.click();
+  await expect(testNestedCall).toHaveText('4');
+
+  const buttonTimeout = page.locator('#buttonTimeout');
+  const testTimeout = page.locator('#testTimeout');
+
+  await buttonTimeout.click();
+  await page.waitForTimeout(1000);
+  await expect(testTimeout).toHaveText('Timeout');
+});

--- a/tests/integrations/call-forwarding/index.html
+++ b/tests/integrations/call-forwarding/index.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Partytown Test Page" />
+    <title>Integration Call Forwarding</title>
+
+    <script>
+      partytown = {
+        forwardCall: ['square', 'nested.square',  'timeout'],
+        logCalls: true,
+        logGetters: true,
+        logSetters: true,
+        logStackTraces: false,
+        logScriptExecution: true,
+      };
+    </script>
+    <script src="/~partytown/debug/partytown.js"></script>
+
+    <script>
+      window.square(4).then((value) => {
+        document.getElementById('testStandardCallQueued').textContent = value;
+      });
+
+      window.nested.square(5).then((value) => {
+        document.getElementById('testNestedCallQueued').textContent = value;
+      });
+    </script>
+
+    <script type="text/partytown">
+      (function() {
+        square = function(value) {
+          return value * value;
+        }
+      })();
+    </script>
+
+    <script type="text/partytown">
+      (function() {
+        nested = {
+          square: function(value) {
+            return value * value;
+          }
+        }
+      })();
+    </script>
+
+    <script type="text/partytown">
+      (function() {
+        timeout = function() {
+          let value = 0;
+
+          for (let index = 0; index < 1000000000; index += 1) {
+            value += index;
+          }
+
+          return value;
+        }
+      })();
+    </script>
+
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif,
+          Apple Color Emoji, Segoe UI Emoji;
+        font-size: 12px;
+      }
+      h1 {
+        margin: 0 0 15px 0;
+      }
+      ul {
+        list-style-type: none;
+        margin: 0;
+        padding: 0;
+      }
+      a {
+        display: block;
+        padding: 16px 8px;
+      }
+      a:link,
+      a:visited {
+        text-decoration: none;
+        color: blue;
+      }
+      a:hover {
+        background-color: #eee;
+      }
+      li {
+        display: flex;
+        margin: 15px 0;
+      }
+      li strong,
+      li code,
+      li button {
+        white-space: nowrap;
+        flex: 1;
+        margin: 0 5px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Integration Event Forwarding</h1>
+    <ul>
+      <li>
+        <strong>Standard call</strong>
+        <button id="buttonStandardCall">square</button>
+        <code id="testStandardCall"></code>
+        <code id="testStandardCallQueued"></code>
+        <script>
+          (function () {
+            const btn = document.getElementById('buttonStandardCall');
+            const testStandardCall = document.getElementById('testStandardCall');
+
+            let value = 0;
+
+            btn.addEventListener('click', function (ev) {
+              window.square(value++).then((result) => {
+                testStandardCall.textContent = result;
+              });
+            });
+          })();
+        </script>
+      </li>
+
+      <li>
+        <strong>Nested call</strong>
+        <button id="buttonNestedCall">square</button>
+        <code id="testNestedCall"></code>
+        <code id="testNestedCallQueued"></code>
+        <script>
+          (function () {
+            const btn = document.getElementById('buttonNestedCall');
+            const testNestedCall = document.getElementById('testNestedCall');
+
+            let value = 0;
+
+            btn.addEventListener('click', function (ev) {
+              window.nested.square(value++).then((result) => {
+                testNestedCall.textContent = result;
+              });
+            });
+          })();
+        </script>
+      </li>
+
+      <li>
+        <strong>Timeout call</strong>
+        <button id="buttonTimeout">timeout</button>
+        <code id="testTimeout"></code>
+        <code></code>
+        <script>
+          (function () {
+            const btn = document.getElementById('buttonTimeout');
+            const testTimeout = document.getElementById('testTimeout');
+
+            let value = 0;
+
+            btn.addEventListener('click', function (ev) {
+              window.timeout().catch((error) => {
+                testTimeout.textContent = error.$error$;
+              });
+            });
+          })();
+        </script>
+      </li>
+    </ul>
+
+    <script type="text/partytown">
+      document.body.classList.add('completed');
+    </script>
+
+    <hr />
+    <p><a href="/tests/">All Tests</a></p>
+    <hr />
+  </body>
+</html>

--- a/tests/unit/forwardCall.spec.ts
+++ b/tests/unit/forwardCall.spec.ts
@@ -1,0 +1,243 @@
+import * as assert from 'uvu/assert';
+import { snippet } from '../../src/lib/main/snippet';
+import { suite } from './utils';
+import { mainForwardCall } from '../../src/lib/sandbox/main-forward-call';
+import { SerializedType, WorkerMessageType } from '../../src/lib/types';
+import { workerForwardedCallHandle } from '../../src/lib/web-worker/worker-forwarded-call';
+
+const test = suite();
+
+const queuedCallsWithoutCallId = (queuedCalls: any[]) => {
+  return queuedCalls.filter((queuedCall) => {
+    return typeof queuedCall !== 'string';
+  });
+};
+
+test('patch multiple functions on same object window.obj, queue calls', ({
+  win,
+  document,
+  navigator,
+}) => {
+  win.partytown = {
+    forwardCall: ['objA.fn0', 'objA.fn1', 'objA.fn2', 'objA.objB.fn3', 'objA.objC.fn4'],
+  };
+  snippet(win, document, navigator, win, false);
+  assert.type(win.objA, 'object');
+  assert.type(win.objA.fn0, 'function');
+  assert.type(win.objA.fn1, 'function');
+  assert.type(win.objA.fn2, 'function');
+  assert.type(win.objA.objB.fn3, 'function');
+  assert.type(win.objA.objC.fn4, 'function');
+  assert.equal(win._ptfc, undefined);
+
+  win.objA.fn0('a').catch(() => {});
+  win.objA.objB.fn3('b').catch(() => {});
+  win.objA.objC.fn4('c').catch(() => {});
+  assert.equal(
+    JSON.stringify(queuedCallsWithoutCallId(win._ptfc)),
+    `[["objA","fn0"],{"0":"a"},["objA","objB","fn3"],{"0":"b"},["objA","objC","fn4"],{"0":"c"}]`
+  );
+});
+
+test('run window.arr.push() in the web worker', ({
+  winId,
+  win,
+  env,
+  worker,
+  document,
+  navigator,
+  top,
+}) => {
+  win.partytown = {
+    forwardCall: ['arr.push'],
+  };
+  snippet(win, document, navigator, top, false);
+
+  mainForwardCall(worker, winId, win);
+
+  win.arr.push('a', 'b').catch(() => {});
+
+  const wwArray = ((env.$window$ as any).arr = []);
+
+  const msg = worker.$messages[0][0][1];
+  workerForwardedCallHandle(msg);
+  assert.equal(wwArray[0], 'a');
+  assert.equal(wwArray[1], 'b');
+});
+
+test('run window.fn() in the web worker', ({
+  winId,
+  win,
+  env,
+  worker,
+  document,
+  navigator,
+  top,
+}) => {
+  win.partytown = {
+    forwardCall: ['fn'],
+  };
+  snippet(win, document, navigator, top, false);
+
+  mainForwardCall(worker, winId, win);
+
+  win.fn('a', 'b').catch(() => {});
+
+  let fnCallArgs: any;
+  (env.$window$ as any).fn = function () {
+    fnCallArgs = arguments;
+  };
+
+  const msg = worker.$messages[0][0][1];
+  workerForwardedCallHandle(msg);
+  assert.equal(fnCallArgs[0], 'a');
+  assert.equal(fnCallArgs[1], 'b');
+});
+
+test('run window.arr.push() call after initialized', ({
+  winId,
+  win,
+  worker,
+  document,
+  navigator,
+  top,
+}) => {
+  win.partytown = {
+    forwardCall: ['arr.push'],
+  };
+  snippet(win, document, navigator, top, false);
+
+  mainForwardCall(worker, winId, win);
+
+  win.arr.push('a', 'b').catch(() => {});
+
+  const msg = worker.$messages[0][0];
+  assert.equal(msg[0], WorkerMessageType.ForwardMainCall);
+  assert.equal(msg[1].$winId$, winId);
+  assert.equal(msg[1].$forward$, ['arr', 'push']);
+  assert.equal(msg[1].$args$[0], SerializedType.Array);
+});
+
+test('run queued window.arr.push() call', async ({
+  winId,
+  win,
+  worker,
+  document,
+  navigator,
+  top,
+}) => {
+  win.partytown = {
+    forwardCall: ['arr.push'],
+  };
+  snippet(win, document, navigator, top, false);
+
+  win.arr.push('a', 'b').catch(() => {});
+
+  mainForwardCall(worker, winId, win);
+
+  assert.equal(worker.$messages.length, 1);
+  const msg = worker.$messages[0][0];
+  assert.equal(msg[0], WorkerMessageType.ForwardMainCall);
+  assert.equal(msg[1].$winId$, winId);
+  assert.equal(msg[1].$forward$, ['arr', 'push']);
+  assert.equal(msg[1].$args$[0], SerializedType.Array);
+});
+
+test('run queued window.fn() call', ({ winId, win, worker, document, navigator, top }) => {
+  win.partytown = {
+    forwardCall: ['fn'],
+  };
+  snippet(win, document, navigator, win, false);
+  win.fn('a', 'b').catch(() => {});
+
+  mainForwardCall(worker, winId, win);
+  assert.equal(worker.$messages.length, 1);
+  const msg = worker.$messages[0][0];
+  assert.equal(msg[0], WorkerMessageType.ForwardMainCall);
+  assert.equal(msg[1].$winId$, winId);
+  assert.equal(msg[1].$forward$, ['fn']);
+  assert.equal(msg[1].$args$[0], SerializedType.Array);
+});
+
+test('patch window.obj.arr.push(), queue calls', ({ win, document, navigator }) => {
+  win.partytown = {
+    forwardCall: ['obj.arr.push', 'a.b.c'],
+  };
+  snippet(win, document, navigator, win, false);
+  assert.type(win.obj, 'object');
+  assert.equal(Array.isArray(win.obj.arr), true);
+  assert.equal(win._ptfc, undefined);
+
+  win.obj.arr.push('a', 'b').catch(() => {});
+  win.a.b.c('z').catch(() => {});
+  assert.equal(
+    JSON.stringify(queuedCallsWithoutCallId(win._ptfc)),
+    `[["obj","arr","push"],{"0":"a","1":"b"},["a","b","c"],{"0":"z"}]`
+  );
+});
+
+test('patch window.arr.push(), queue calls', ({ win, document, navigator }) => {
+  win.partytown = {
+    forwardCall: ['arr.push'],
+  };
+  snippet(win, document, navigator, win, false);
+  assert.equal(Array.isArray(win.arr), true);
+  assert.type(win.arr.push, 'function');
+  assert.equal(win._ptfc, undefined);
+
+  win.arr.push('a', 'b').catch(() => {});
+  assert.equal(
+    JSON.stringify(queuedCallsWithoutCallId(win._ptfc)),
+    `[["arr","push"],{"0":"a","1":"b"}]`
+  );
+});
+
+test('patch window.obj.fn(), queue calls', ({ win, document, navigator }) => {
+  win.partytown = {
+    forwardCall: ['obj.fn'],
+  };
+  snippet(win, document, navigator, win, false);
+  assert.type(win.fn, 'undefined');
+  assert.type(win.obj, 'object');
+  assert.type(win.obj.fn, 'function');
+  assert.equal(win._ptfc, undefined);
+
+  win.obj.fn('a', 'b').catch(() => {});
+  assert.equal(
+    JSON.stringify(queuedCallsWithoutCallId(win._ptfc)),
+    `[["obj","fn"],{"0":"a","1":"b"}]`
+  );
+});
+
+test('patch window.fn(), queue calls', ({ win, document, navigator }) => {
+  win.partytown = {
+    forwardCall: ['fn'],
+  };
+  snippet(win, document, navigator, win, false);
+  assert.type(win.fn, 'function');
+  assert.equal(win._ptfc, undefined);
+
+  win.fn('a', 'b').catch(() => {});
+  assert.equal(JSON.stringify(queuedCallsWithoutCallId(win._ptfc)), `[["fn"],{"0":"a","1":"b"}]`);
+
+  win.fn('c').catch(() => {});
+  assert.equal(
+    JSON.stringify(queuedCallsWithoutCallId(win._ptfc)),
+    `[["fn"],{"0":"a","1":"b"},["fn"],{"0":"c"}]`
+  );
+});
+
+test('no window._ptfc if no forward config', ({ window, document, navigator }) => {
+  snippet(window, document, navigator, window, false);
+  assert.equal(window._ptfc, undefined);
+
+  window.partytown = {};
+  snippet(window, document, navigator, window, false);
+  assert.equal(window._ptfc, undefined);
+
+  window.partytown = { forwardCall: [] };
+  snippet(window, document, navigator, window, false);
+  assert.equal(window._ptfc, undefined);
+});
+
+test.run();

--- a/tests/unit/integration.spec.ts
+++ b/tests/unit/integration.spec.ts
@@ -5,16 +5,17 @@ import { createSnippet } from '../../src/integration/snippet';
 const test = suite();
 
 test('partytownSnippet overwrite existing window.partytown', ({ snippetCode, run, win }) => {
-  win.partytown = { lib: 'libpath-1', forward: ['a'] };
+  win.partytown = { lib: 'libpath-1', forward: ['a'], forwardCall: ['c'] };
   const code = createSnippet(
     {
       lib: 'libpath-2',
       forward: ['b'],
+      forwardCall: ['d'],
     },
     snippetCode
   );
   run(code);
-  assert.equal(win.partytown, { lib: 'libpath-2', forward: ['a', 'b'] });
+  assert.equal(win.partytown, { lib: 'libpath-2', forward: ['a', 'b'], forwardCall: ['c', 'd'] });
 });
 
 test('partytownSnippet merge existing window.partytown', ({ snippetCode, run, win }) => {
@@ -26,7 +27,7 @@ test('partytownSnippet merge existing window.partytown', ({ snippetCode, run, wi
     snippetCode
   );
   run(code);
-  assert.equal(win.partytown, { lib: 'libpath', forward: ['a', 'b'] });
+  assert.equal(win.partytown, { lib: 'libpath', forward: ['a', 'b'], forwardCall: [] });
 });
 
 test('partytownSnippet w/ existing window.partytown.forward', ({ snippetCode, run, win }) => {
@@ -38,7 +39,19 @@ test('partytownSnippet w/ existing window.partytown.forward', ({ snippetCode, ru
     snippetCode
   );
   run(code);
-  assert.equal(win.partytown, { forward: ['a', 'b'] });
+  assert.equal(win.partytown, { forward: ['a', 'b'], forwardCall: [] });
+});
+
+test('partytownSnippet w/ existing window.partytown.forwardCall', ({ snippetCode, run, win }) => {
+  win.partytown = { forwardCall: ['a'] };
+  const code = createSnippet(
+    {
+      forwardCall: ['b'],
+    },
+    snippetCode
+  );
+  run(code);
+  assert.equal(win.partytown, { forward: [], forwardCall: ['a', 'b'] });
 });
 
 test('partytownSnippet w/ config.forward', ({ snippetCode, run, win }) => {
@@ -49,19 +62,30 @@ test('partytownSnippet w/ config.forward', ({ snippetCode, run, win }) => {
     snippetCode
   );
   run(code);
-  assert.equal(win.partytown, { forward: ['a'] });
+  assert.equal(win.partytown, { forward: ['a'], forwardCall: [] });
+});
+
+test('partytownSnippet w/ config.forward', ({ snippetCode, run, win }) => {
+  const code = createSnippet(
+    {
+      forwardCall: ['a'],
+    },
+    snippetCode
+  );
+  run(code);
+  assert.equal(win.partytown, { forward: [], forwardCall: ['a'] });
 });
 
 test('partytownSnippet w/ config', ({ snippetCode, run, win }) => {
   const code = createSnippet({}, snippetCode);
   run(code);
-  assert.equal(win.partytown, { forward: [] });
+  assert.equal(win.partytown, { forward: [], forwardCall: [] });
 });
 
 test('partytownSnippet w/out config', ({ snippetCode, run, win }) => {
   const code = (createSnippet as any)(null, snippetCode);
   run(code);
-  assert.equal(win.partytown, { forward: [] });
+  assert.equal(win.partytown, { forward: [], forwardCall: [] });
 });
 
 test.run();

--- a/tests/unit/utils.ts
+++ b/tests/unit/utils.ts
@@ -83,6 +83,7 @@ function getWindow(): any {
   const win: any = createWindow();
   win.top = win.self = win.parent = win.window = win;
   win.document.readyState = 'complete';
+  win.postMessage = () => {}
   return win;
 }
 


### PR DESCRIPTION
This PR adds `forwardCall` functionality. This modification allows 2-way communication between main thread and webworker to retrieve return value of forwarded functions. Such functionality can be usefull when working with more complex third-party scripts when return value of them required in main thread (such as mixpanel and etc). Otherwise developers have to either implement this kind of forwarding themselfs or entirely put additional logic to sandboxed script.