### PR TITLE
Webpack copy plugin error fix

### DIFF
--- a/docs/copy-library-files.md
+++ b/docs/copy-library-files.md
@@ -102,14 +102,12 @@ const partytown = require('@builder.io/partytown/utils');
 
 module.exports = {
   plugins: [
-    new CopyPlugin({
-      patterns: [
+    new CopyPlugin([
         {
           from: partytown.libDirPath(),
           to: path.join(__dirname, 'public', '~partytown'),
         },
-      ],
-    }),
+      ]),
   ],
 };
 ```


### PR DESCRIPTION
I was testing this plugin implementation and I got an "Options should be array" error. After investigation I found that the webpack copy plugin docs are wrong.

See more here: https://github.com/webpack-contrib/copy-webpack-plugin/issues/455