### PR TITLE
test: Test cases for NodeFilter and TreeWalker

### DIFF
--- a/tests/platform/node-filter/index.html
+++ b/tests/platform/node-filter/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Partytown Test Page" />
+    <title>NodeFilter</title>
+    <script>
+      partytown = {
+        logCalls: true,
+        logGetters: true,
+        logSetters: true,
+        logStackTraces: false,
+        logScriptExecution: true,
+      };
+    </script>
+    <script src="/~partytown/debug/partytown.js"></script>
+  </head>
+  <body>
+    <h1>NodeFilter</h1>
+    <div id="nodeFilterProps"></div>
+    <script type="text/partytown">
+      (function () {
+        const nodeFilterEntries = Object.entries(NodeFilter);
+        document.getElementById('nodeFilterProps').textContent = 
+          nodeFilterEntries.map(([k, v]) => `${k}: ${v}`).join(', ');
+      })();
+    </script>
+
+    <hr />
+    <p><a href="/tests/">All Tests</a></p>
+  </body>
+</html>

--- a/tests/platform/node-filter/node-filter.spec.ts
+++ b/tests/platform/node-filter/node-filter.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+
+test('NodeFilter', async ({ page }) => {
+  await page.goto('/tests/platform/node-filter/');
+  await page.waitForSelector('#nodeFilterProps');
+  const resultDiv = page.locator('#nodeFilterProps');
+  await expect(resultDiv).toContainText('FILTER_ACCEPT');
+});
+

--- a/tests/platform/tree-walker/index.html
+++ b/tests/platform/tree-walker/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Partytown Test Page" />
+    <title>TreeWalker</title>
+    <script>
+      partytown = {
+        logCalls: true,
+        logGetters: true,
+        logSetters: true,
+        logStackTraces: false,
+        logScriptExecution: true,
+      };
+    </script>
+    <script src="/~partytown/debug/partytown.js"></script>
+  </head>
+  <body>
+    <h1>TreeWalker</h1>
+    <div id="walkerResult"></div>
+    <script type="text/partytown">
+      (function () {
+        const tw = document.createTreeWalker(document.body, 1);
+        result = [];
+        do {
+          result.push(tw.currentNode.nodeName);
+        } while (tw.nextNode());
+        document.getElementById('walkerResult').textContent = result.join(' ');
+      })();
+    </script>
+
+    <hr />
+    <p><a href="/tests/">All Tests</a></p>
+  </body>
+</html>

--- a/tests/platform/tree-walker/tree-walker.spec.ts
+++ b/tests/platform/tree-walker/tree-walker.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+
+test('TreeWalker', async ({ page }) => {
+  await page.goto('/tests/platform/tree-walker/');
+  await page.waitForSelector('#walkerResult');
+  const resultDiv = page.locator('#walkerResult');
+  await expect(resultDiv).toHaveText('BODY H1 DIV SCRIPT');
+});
+


### PR DESCRIPTION
This PR contains test cases for [NodeFilter](https://www.w3.org/TR/DOM-Level-2-Traversal-Range/traversal.html#Traversal-NodeFilter) API and [TreeWalker](https://developer.mozilla.org/en-US/docs/Web/API/TreeWalker) API. They are mainly for testing issues #253 and #254.

- `tests/platform/node-filter`: test case for NodeFilter
- `tests/platform/tree-walker`: test case for TreeWalker

### To run the test cases:
```bash
npx playwright test tests/platform/node-filter --browser=chromium
npx playwright test tests/platform/tree-walker --browser=chromium
```

### To view and run the test cases manually:
```bash
npm run serve
```
Then open the following pages in browser:
http://localhost:4000/tests/platform/node-filter/
http://localhost:4000/tests/platform/tree-walker/