### PR TITLE
resolving url for Image

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -374,7 +374,7 @@ export type SerializedInstance =
 /**
  * @public
  */
-export type ResolveUrlType = 'fetch' | 'xhr' | 'script' | 'iframe';
+export type ResolveUrlType = 'fetch' | 'xhr' | 'script' | 'iframe' | 'image';
 
 /**
  * https://partytown.builder.io/configuration

--- a/src/lib/web-worker/worker-image.ts
+++ b/src/lib/web-worker/worker-image.ts
@@ -23,12 +23,12 @@ export const createImageConstructor = (env: WebWorkerEnvironment) =>
     }
     set src(src: string) {
       if (debug && webWorkerCtx.$config$.logImageRequests) {
-        logWorker(`Image() request: ${resolveUrl(env, src, null)}`, env.$winId$);
+        logWorker(`Image() request: ${resolveUrl(env, src, 'image')}`, env.$winId$);
       }
 
       this.s = src;
 
-      fetch(resolveUrl(env, src, null), {
+      fetch(resolveUrl(env, src, 'image'), {
         mode: 'no-cors',
         credentials: 'include',
         keepalive: true,


### PR DESCRIPTION
In Meta Pixel they use Image for sending the analytics.
But the flow does not use the resolveUrl logic, which get's us CORS error.

fixed issue: https://github.com/BuilderIO/partytown/issues/306