### PR TITLE
added a test for image resolveUrl

### DIFF
--- a/tests/platform/image/image.spec.ts
+++ b/tests/platform/image/image.spec.ts
@@ -3,6 +3,9 @@ import { test, expect } from '@playwright/test';
 test('image', async ({ page }) => {
   await page.goto('/tests/platform/image/');
 
+  const resolveUrlCalled = new Promise(resolve =>
+    page.on('request', request => request.url().includes('resolvedUrl') && resolve(true)));
+
   await page.waitForSelector('.testImageOnLoad');
   const testImageOnLoad = page.locator('#testImageOnLoad');
   await expect(testImageOnLoad).toHaveText('load');
@@ -42,4 +45,7 @@ test('image', async ({ page }) => {
   await page.waitForSelector('.testImgSrc');
   const testImgSrc = page.locator('#testImgSrc');
   await expect(testImgSrc).toHaveText('dot.gif?imageSrcTest');
+
+  // Making sure the network calls for the images went through the resolveUrl function
+  expect(await resolveUrlCalled).toEqual(true);
 });

--- a/tests/platform/image/index.html
+++ b/tests/platform/image/index.html
@@ -47,6 +47,12 @@
       partytown = {
         logImageRequests: true,
         logScriptExecution: true,
+        resolveUrl: (url, location, type) => {
+          if (type === 'image') {
+            url.searchParams.append('resolvedUrl', true);
+          }
+          return url;
+        },
       };
     </script>
     <script src="/~partytown/debug/partytown.js"></script>


### PR DESCRIPTION
As requested here:
https://github.com/BuilderIO/partytown/pull/307
Added a check that images requests goes through resolveUrl function
@adamdbradley 