### PR TITLE
fix: Next.js NPM Install

### DIFF
--- a/docs/nextjs.md
+++ b/docs/nextjs.md
@@ -13,7 +13,7 @@ As of Next.js `v12.1.1-canary.11`, the `<Script/>` component now provides an exp
 > Below are the instructions if you are not using the experimental [Worker Strategy](#worker-strategy).
 
 ```bash
-npm install @builder.io/partytown
+npm install "@builder.io/partytown"
 ```
 
 ## Configure


### PR DESCRIPTION
Double quotes are needed, so npm install "@builder.io/partytown"