### PR TITLE
feat: add return value hook

### DIFF
--- a/src/integration/api.md
+++ b/src/integration/api.md
@@ -37,6 +37,8 @@ export interface PartytownConfig {
     mainWindowAccessors?: string[];
     resolveUrl?(url: URL, location: Location, type: ResolveUrlType): URL | undefined | null;
     // (undocumented)
+    returnValue?: ReturnValueHook;
+    // (undocumented)
     set?: SetHook;
     swPath?: string;
 }
@@ -49,6 +51,11 @@ export const partytownSnippet: (config?: PartytownConfig | undefined) => string;
 
 // @public (undocumented)
 export type ResolveUrlType = 'fetch' | 'xhr' | 'script' | 'iframe' | 'image';
+
+// Warning: (ae-forgotten-export) The symbol "ReturnValueHookOptions" needs to be exported by the entry point index.d.ts
+//
+// @public (undocumented)
+export type ReturnValueHook = (opts: ReturnValueHookOptions) => any;
 
 // @public
 export const SCRIPT_TYPE = "text/partytown";

--- a/src/integration/index.ts
+++ b/src/integration/index.ts
@@ -19,5 +19,6 @@ export type {
   ApplyHook,
   GetHook,
   SetHook,
+  ReturnValueHook,
   ResolveUrlType,
 } from '../lib/types';

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -439,6 +439,7 @@ export interface PartytownConfig {
   get?: GetHook;
   set?: SetHook;
   apply?: ApplyHook;
+  returnValue?: ReturnValueHook;
   /**
    * An absolute path to the root directory which Partytown library files
    * can be found. The library path must start and end with a `/`.
@@ -510,6 +511,11 @@ export type SetHook = (opts: SetHookOptions) => any;
  */
 export type ApplyHook = (opts: ApplyHookOptions) => any;
 
+/**
+ * @public
+ */
+export type ReturnValueHook = (opts: ReturnValueHookOptions) => any;
+
 export interface HookOptions {
   name: string;
   continue: Symbol;
@@ -538,6 +544,13 @@ export interface SetHookOptions extends HookOptions {
 export interface ApplyHookOptions extends HookOptions {
   args: any[];
 }
+
+/**
+ * @public
+ */
+export type ReturnValueHookOptions = (GetHookOptions | SetHookOptions | ApplyHookOptions) & {
+  rtnValue: any;
+};
 
 export interface MainWindow extends Window {
   partytown?: PartytownConfig;

--- a/src/lib/web-worker/init-web-worker.ts
+++ b/src/lib/web-worker/init-web-worker.ts
@@ -24,9 +24,11 @@ export const initWebWorker = (initWebWorkerData: InitWebWorkerData) => {
   delete (self as any).postMessage;
   delete (self as any).WorkerGlobalScope;
 
-  (commaSplit('resolveUrl,get,set,apply') as any).map((configName: keyof PartytownConfig) => {
-    if (config[configName]) {
-      config[configName] = new Function('return ' + config[configName])();
+  (commaSplit('resolveUrl,get,set,apply,returnValue') as any).map(
+    (configName: keyof PartytownConfig) => {
+      if (config[configName]) {
+        config[configName] = new Function('return ' + config[configName])();
+      }
     }
-  });
+  );
 };

--- a/src/lib/web-worker/worker-proxy.ts
+++ b/src/lib/web-worker/worker-proxy.ts
@@ -155,6 +155,13 @@ export const getter: Getter = (
 
   rtnValue = queue(instance, applyPath, CallType.Blocking, undefined, groupedGetters);
 
+  if (webWorkerCtx.$config$.returnValue) {
+    rtnValue = webWorkerCtx.$config$.returnValue({
+      ...createHookOptions(instance, applyPath),
+      rtnValue,
+    });
+  }
+
   logWorkerGetter(instance, applyPath, rtnValue, false, !!groupedGetters);
 
   return rtnValue;
@@ -211,7 +218,6 @@ export const callMethod: CallMethod = (
   }
 
   methodName = applyPath[len(applyPath) - 1];
-  applyPath = [...applyPath, serializeInstanceForMain(instance, args)];
 
   callType =
     callType ||
@@ -229,9 +235,26 @@ export const callMethod: CallMethod = (
     logDimensionCacheClearMethod(instance, methodName);
   }
 
-  rtnValue = queue(instance, applyPath, callType, assignInstanceId, undefined, buffer);
+  const applyPathWithInstanceForMain = [...applyPath, serializeInstanceForMain(instance, args)];
 
-  logWorkerCall(instance, applyPath, args, rtnValue);
+  rtnValue = queue(
+    instance,
+    applyPathWithInstanceForMain,
+    callType,
+    assignInstanceId,
+    undefined,
+    buffer
+  );
+
+  if (webWorkerCtx.$config$.returnValue) {
+    rtnValue = webWorkerCtx.$config$.returnValue({
+      ...createHookOptions(instance, applyPath),
+      args,
+      rtnValue,
+    });
+  }
+
+  logWorkerCall(instance, applyPathWithInstanceForMain, args, rtnValue);
 
   return rtnValue;
 };

--- a/tests/integrations/config/config.spec.ts
+++ b/tests/integrations/config/config.spec.ts
@@ -28,6 +28,9 @@ test('integration config', async ({ page }) => {
   const testApplyHook = page.locator('#testApplyHook');
   await expect(testApplyHook).toHaveText('prevented document.write()');
 
-  const testApplyArgs = page.locator('#testApplyArgs');
-  await expect(testApplyArgs).toHaveText('1.21');
+  const testReturnValueGetter = page.locator('#testReturnValueGetter');
+  await expect(testReturnValueGetter).toHaveText('hooked-mph=88');
+
+  const testReturnValueApply = page.locator('#testReturnValueApply');
+  await expect(testReturnValueApply).toHaveText('hooked-attribute-testReturnValueApply');
 });

--- a/tests/integrations/config/index.html
+++ b/tests/integrations/config/index.html
@@ -77,6 +77,17 @@
           }
           return opts.continue;
         },
+        returnValue(opts) {
+          if (opts.nodeName === '#document' && opts.name === 'cookie') {
+            return 'hooked-' + opts.rtnValue;
+          }
+
+          if (opts.name === 'getAttribute' && opts.args && opts.args[0] === 'id') {
+            return 'hooked-attribute-' + opts.rtnValue;
+          }
+
+          return opts.rtnValue;
+        },
         logCalls: true,
         logGetters: true,
         logSetters: true,
@@ -180,6 +191,30 @@
             const elm = document.getElementById('testApplyArgs');
             elm.setAttribute('gw', '9.99');
             elm.textContent = elm.getAttribute('gw');
+          })();
+        </script>
+      </li>
+
+      <li>
+        <strong>returnValue() on getter</strong>
+        <code id="testReturnValueGetter"></code>
+        <script>
+          document.cookie = 'mph=88';
+        </script>
+        <script type="text/partytown">
+          (function () {
+            document.getElementById('testReturnValueGetter').textContent = document.cookie;
+          })();
+        </script>
+      </li>
+
+      <li>
+        <strong>returnValue() on function call</strong>
+        <code id="testReturnValueApply"></code>
+        <script type="text/partytown">
+          (function () {
+            const idAttrValue = document.getElementById('testReturnValueApply').getAttribute('id');
+            document.getElementById('testReturnValueApply').textContent = idAttrValue;
           })();
         </script>
       </li>


### PR DESCRIPTION
Add a new hook for intercepting return value. Can be used to modify return value or prevent an object from being returned.

```javascript
        returnValue(opts) {
          if (opts.nodeName === '#document' && opts.name === 'cookie') {
            return 'hooked-' + opts.rtnValue;
          }

          return opts.rtnValue;
        }
```