### PR TITLE
Check for `Event` object with `getConstructorName` during worker serialization

### DIFF
--- a/src/lib/sandbox/main-serialization.ts
+++ b/src/lib/sandbox/main-serialization.ts
@@ -97,7 +97,7 @@ const serializeObjectForWorker = (
     added.add(obj);
     for (propName in obj) {
       if (isValidMemberName(propName)) {
-        if (propName === 'path' && obj[Symbol.toStringTag]?.endsWith("Event")) {
+        if (propName === 'path' && getConstructorName(obj).endsWith("Event")) {
           propValue = obj.composedPath();
         } else {
           propValue = obj[propName];

--- a/src/lib/sandbox/main-serialization.ts
+++ b/src/lib/sandbox/main-serialization.ts
@@ -97,7 +97,7 @@ const serializeObjectForWorker = (
     added.add(obj);
     for (propName in obj) {
       if (isValidMemberName(propName)) {
-        if (propName === 'path' && obj instanceof Event) {
+        if (propName === 'path' && obj[Symbol.toStringTag].endsWith("Event")) {
           propValue = obj.composedPath();
         } else {
           propValue = obj[propName];

--- a/src/lib/sandbox/main-serialization.ts
+++ b/src/lib/sandbox/main-serialization.ts
@@ -97,7 +97,7 @@ const serializeObjectForWorker = (
     added.add(obj);
     for (propName in obj) {
       if (isValidMemberName(propName)) {
-        if (propName === 'path' && obj[Symbol.toStringTag].endsWith("Event")) {
+        if (propName === 'path' && obj[Symbol.toStringTag]?.endsWith("Event")) {
           propValue = obj.composedPath();
         } else {
           propValue = obj[propName];


### PR DESCRIPTION
This fixes #284 and also fixes #313 and also fixes #178.

A previous PR (#269) tried checking if the object to serialize for the worker was an Event using `obj instanceof Event`. However, this was failing for some reason. I changed the check to use [`getConstructorName`](https://github.com/BuilderIO/partytown/blob/main/src/lib/utils.ts#L14-L26).

I did some brief testing on a Next app using the build output and the deprecation warning doesn't appear anymore.