### PR TITLE
Clean up forwarded functions after timeout and fallback

### DIFF
--- a/src/lib/main/snippet.ts
+++ b/src/lib/main/snippet.ts
@@ -98,7 +98,6 @@ export function snippet(
     // remove any previously patched functions
     if (top == win) {
       (config!.forward || []).map((function(forwardProps) {
-        mainForwardFn = win;
         delete win[forwardProps.split(".")[0] as any];
       }))
     }

--- a/src/lib/main/snippet.ts
+++ b/src/lib/main/snippet.ts
@@ -94,6 +94,15 @@ export function snippet(
     }
 
     clearFallback();
+
+    // remove any previously patched functions
+    if (top == win) {
+      (config!.forward || []).map((function(forwardProps) {
+        mainForwardFn = win;
+        delete win[forwardProps.split(".")[0] as any];
+      }))
+    }
+
     for (i = 0; i < scripts!.length; i++) {
       script = doc.createElement('script');
       script.innerHTML = scripts![i].innerHTML;


### PR DESCRIPTION
It's very common for third party libraries to initialize with an embedded script that initializes a global variable only if it isn't already defined. For example, here is an excerpt from the Segment embed code:

```javascript
window.analytics=window.analytics||[];
```

If Partytown hasn't fully initialized before the fallback timeout is called, then these embedded scripts will run in the main thread but their global variable names will already be defined if a forwarding function was defined. This can prevent the proper initialization of these libraries in fallback mode. Continuing with the Segment example, if you configure Partytown with `forward: ['analytics.identify`]` then `window.analytics` will be an object rather than an array when the Segment embed code runs and the code will fail when executing `window.analytics.push()`.

The changes in this PR update the fallback function to delete any globals that Partytown created before the scripts are run. This prevents third party scripts from getting confused about whether or not they've already been initialized.