### PR TITLE
partytownVite does not copy resource to static dir

### DIFF
--- a/docs/sveltekit.md
+++ b/docs/sveltekit.md
@@ -60,6 +60,7 @@ import { partytownVite } from '@builder.io/partytown/utils'
 const config = {
   plugins: [
     sveltekit(),
+    // THIS STEP DOESN'T WORK. WORK AROUND. MANUALLY COPY partytown-sw.js to /static/~partytown/
     partytownVite({
       // `dest` specifies where files are copied to in production
       dest: join(process.cwd(), 'static', '~partytown')


### PR DESCRIPTION
Hello.

I followed the above steps, but when I deploy the solution to production. I receive a 404 when the script attempts to retrieve `partytown-sw.js`. The culprit seems to be `partytownVite` because if I manually copy `partytown-sw.js` to `/static/~partytown/` the bug is resolved.  

See https://github.com/cesarnml/partytown-bug for minimal reproduction.