### PR TITLE
fix: gtm scripts not working with loadScriptsOnMainThread by id

### DIFF
--- a/src/lib/web-worker/worker-constants.ts
+++ b/src/lib/web-worker/worker-constants.ts
@@ -65,7 +65,7 @@ export const structureChangingMethodNames = /*#__PURE__*/ commaSplit(
 
 /** setters that could change dimensions of elements */
 export const dimensionChangingSetterNames = /*#__PURE__*/ commaSplit(
-  'className,width,height,hidden,innerHTML,innerText,textContent'
+  'className,width,height,hidden,innerHTML,innerText,textContent,text'
 );
 
 /** method calls that could change dimensions of elements */

--- a/src/lib/web-worker/worker-script.ts
+++ b/src/lib/web-worker/worker-script.ts
@@ -39,6 +39,7 @@ export const patchHTMLScriptElement = (WorkerHTMLScriptElement: any, env: WebWor
     },
 
     textContent: innerHTMLDescriptor,
+    text: innerHTMLDescriptor,
 
     type: {
       get() {

--- a/tests/integrations/load-scripts-on-main-thread/index.html
+++ b/tests/integrations/load-scripts-on-main-thread/index.html
@@ -15,7 +15,8 @@
       logScriptExecution: true,
       loadScriptsOnMainThread: [
         `http://${location.host}/tests/integrations/load-scripts-on-main-thread/test-script.js`,
-        `inline-test-script`
+        `inline-test-script`,
+        `inline-text-test-script`
       ],
     };
   </script>
@@ -79,29 +80,29 @@
 <body>
 <h1>Load scripts on main thread 🎉</h1>
 <ul>
-    <li>
-      <strong>Script Type:</strong>
-      <code id='testScriptType'></code>
-      <script type='text/partytown'>
-        (() => {
-          const scriptElement = document.getElementById('testScript');
-          const codeElement = document.getElementById('testScriptType');
-          
-          codeElement.innerText = scriptElement.type;
-        })()
-      </script>
-    </li>
-    <li>
-      <strong>Script Source:</strong>
-      <code id='testScriptSource'></code>
-      <script type='text/partytown'>
-        (() => {
-          const scriptElement = document.getElementById('testScript');
-          const codeElement = document.getElementById('testScriptSource');
-          
-          codeElement.innerText = scriptElement.src;
-        })()
-      </script>
+  <li>
+    <strong>Script Type:</strong>
+    <code id='testScriptType'></code>
+    <script type='text/partytown'>
+      (() => {
+        const scriptElement = document.getElementById('testScript');
+        const codeElement = document.getElementById('testScriptType');
+        
+        codeElement.innerText = scriptElement.type;
+      })()
+    </script>
+  </li>
+  <li>
+    <strong>Script Source:</strong>
+    <code id='testScriptSource'></code>
+    <script type='text/partytown'>
+      (() => {
+        const scriptElement = document.getElementById('testScript');
+        const codeElement = document.getElementById('testScriptSource');
+        
+        codeElement.innerText = scriptElement.src;
+      })()
+    </script>
   </li>
   <li>
     <strong>Partytown Config:</strong>
@@ -127,13 +128,35 @@
         script.type = "text/javascript";
         script.id = "inline-test-script";
         script.innerHTML = `
-          document.getElementById('testInlineScript');
-
-          const testEl = document.getElementById('testInlineScript');
-          testEl.className = 'testInlineScript';
-          testEl.innerHTML = globalVariable;
+          (function () {
+            const testEl = document.getElementById('testInlineScript');
+            testEl.className = 'testInlineScript';
+            testEl.innerHTML = globalVariable;
+          })();
         `;
 
+        document.body.appendChild(script);
+      })();
+    </script>
+  </li>
+  <li>
+    <strong>Inline script with text</strong>
+    <code id="testInlineTextScript"></code>
+    <script type="text/javascript">const globalVariable2 = 12;</script>
+    <script type="text/partytown">
+      (function () {
+        const script = document.createElement('script');
+
+        script.type = "text/javascript";
+        script.id = "inline-text-test-script";
+
+        script.text = `
+          (function () {
+            const testEl = document.getElementById('testInlineTextScript');
+            testEl.className = 'testInlineTextScript';
+            testEl.innerHTML = globalVariable2;
+          })();
+        `;
         document.body.appendChild(script);
       })();
     </script>

--- a/tests/integrations/load-scripts-on-main-thread/load-scripts-on-main-thread.spec.ts
+++ b/tests/integrations/load-scripts-on-main-thread/load-scripts-on-main-thread.spec.ts
@@ -10,4 +10,8 @@ test('integration window accessor', async ({ page }) => {
   await page.waitForSelector('.testInlineScript');
   const testInlineScript = page.locator('#testInlineScript');
   await expect(testInlineScript).toHaveText('12');
+
+  await page.waitForSelector('.testInlineTextScript');
+  const testInlineTextScript = page.locator('#testInlineTextScript');
+  await expect(testInlineTextScript).toHaveText('12');
 });


### PR DESCRIPTION
GTM uses the `text` field when settings up an element.

Ex. from the gtm script
![image](https://user-images.githubusercontent.com/747304/231789770-72959c17-7549-4ba9-a21f-6463918840f1.png)

Added field watch for `text` to the element patch code.
Test code is added is well.