### PR TITLE
docs(table-of-content): update qwik link

### DIFF
--- a/docs/_table-of-contents.md
+++ b/docs/_table-of-contents.md
@@ -18,7 +18,7 @@
   - [HTML](/html)
   - [Next.js](/nextjs)
   - [Nuxt](/nuxt)
-  - [Qwik](https://qwik.builder.io/integrations/partytown/)
+  - [Qwik](https://qwik.builder.io/docs/integrations/partytown/)
   - [React](/react)
   - [Remix](/remix)
   - [Shopify](/shopify-plugin)


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

This PR updates the link to the Qwik integration documentation in the docs/_table-of-contents.md file.
- close #400 
# Use cases and why

The change is necessary to ensure users are directed to the correct documentation page for the Qwik integration.

- 1. One use case is when a user wants to learn more about the Qwik integration and clicks on the link in the table of contents.
- 2. Another use case is when a user is browsing the documentation and wants to navigate between different sections. The updated link ensures they end up at the right location.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality