### PR TITLE
feat: support for `nonce` prop

### DIFF
--- a/src/react/snippet.tsx
+++ b/src/react/snippet.tsx
@@ -9,7 +9,9 @@ import { partytownSnippet } from '@builder.io/partytown/integration';
  *
  * @public
  */
-export interface PartytownProps extends PartytownConfig {}
+export interface PartytownProps extends PartytownConfig {
+  nonce?: string;
+}
 
 /**
  * The React `<Partytown/>` component should be placed within the `<head>`
@@ -20,7 +22,7 @@ export interface PartytownProps extends PartytownConfig {}
  *
  * @public
  */
-export const Partytown = (props: PartytownProps = {}): any => {
+export const Partytown = ({ nonce, ...props }: PartytownProps = {}): any => {
   // purposely not using useState() or useEffect() so this component
   // can also work as a React Server Component
 
@@ -35,6 +37,7 @@ export const Partytown = (props: PartytownProps = {}): any => {
       const scriptElm = document.createElement('script');
       scriptElm.dataset.partytown = '';
       scriptElm.innerHTML = partytownSnippet(props);
+      scriptElm.nonce = nonce;
       document.head.appendChild(scriptElm);
     }
     // should only append this script once per document, and is not dynamic
@@ -48,7 +51,13 @@ export const Partytown = (props: PartytownProps = {}): any => {
   // add the same script to the <head>.
   const innerHTML = partytownSnippet(props) + 'document.currentScript.dataset.partytown="";';
 
-  return <script suppressHydrationWarning dangerouslySetInnerHTML={{ __html: innerHTML }} />;
+  return (
+    <script
+      suppressHydrationWarning
+      dangerouslySetInnerHTML={{ __html: innerHTML }}
+      nonce={nonce}
+    />
+  );
 };
 
 interface PartytownDocument extends Document {


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Add an optional `nonce` prop to be applied to the script. Fixes https://github.com/BuilderIO/partytown/issues/299

# Use cases and why

Some users are using content security policies are required to append a `nonce` attribute to scripts, otherwise they won't be executed by the browser

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
