### PR TITLE
fix: partytown link to qwik integration

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -10,7 +10,7 @@ Partytown can work with any HTML page, and doesn't require a specific framework.
 - [HTML](/html)
 - [NextJS](/nextjs)
 - [Nuxt](/nuxt)
-- [Qwik](https://qwik.builder.io/integrations/integration/partytown/)
+- [Qwik](https://qwik.builder.io/docs/integrations/partytown/)
 - [React](/react)
 - [Remix](/remix)
 - [Shopify Hydrogen](/shopify-hydrogen)


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

The link to the qwik documentation page about integrating partytown seems to be broken

# Use cases and why

As a user of the partytown website,
When i click on the link for qwik integration for partytown
I should be redirected to an existing page, not a 404

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
