### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -9,7 +9,7 @@ What's different from most web development libraries is that Partytown does _not
 ## Install NPM package
 
 ```
-npm install @builder.io/partytown
+npm install "@builder.io/partytown"
 ```
 
 ## Next Steps


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

When installing in PowerShell using node v18.16.0 and npm 9.5.1 an error occurs with the command `npm install @builder.io/partytown`. A change to use `npm install "@builder.io/partytown"` fixes the issue.

Exact error here:
```powershell
At line:1 char:13
+ npm install @builder.io/partytown
The splatting operator '@' cannot be used to reference variables in an expression. '@builder' can be used only as an argument to a command. To reference variables in an expression use '$builder'.      
    + CategoryInfo          : ParserError: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : SplattingNotPermitted
```
# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. Installing Partytown on Windows systems

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
