### PR TITLE
docs: show full event forwarding example

### DIFF
--- a/docs/forwarding-events.md
+++ b/docs/forwarding-events.md
@@ -18,10 +18,12 @@ Because GTM and Facebook Pixel objects are added immediately in the `<head>` by 
 
 However, since GTM and Facebook Pixel were actually loaded in the web worker, then we need to forward these calls. The `forward` config is used to set which `window` variables should be patched and forwarded on. The forward string value is of the function to call, and since GTM is pushing to an array, the function to call is `dataLayer.push`.
 
-```json
-{
-  "forward": ["dataLayer.push", "fbq"]
-}
+```js
+<script>
+  partytown = {
+    forward: ['dataLayer.push', 'fbq']
+  };
+</script>
 ```
 
 Notice the forward configs are just strings, not actual objects. We're using strings here so we can easily serialize what service variable was called, along with the function argument values. When the web worker receives the information, it then knows how to correctly apply the call and arguments that were fired from the main thread.


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

The current page is quite confusing as it doesn't say where the JSON config goes. It sounds like it should go in a `partytown.json` or something. If I understood correctly from other pages then it goes in a `script` block which does not have `type="text/partytown"` and assigns it to a `partytown` variable.

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
