### PR TITLE
docs: overhaul SvelteKit guide

### DIFF
--- a/docs/sveltekit.md
+++ b/docs/sveltekit.md
@@ -58,16 +58,6 @@ const config = {
 export default config
 ```
 
-The above will handle `dev` mode. For `build`, you will need to update your `package.json`:
-```json
-// package.json
-{
-  "scripts": {
-    "build": "partytown copylib .svelte-kit/output/client/~partytown && vite build",
-  }
-}
-```
-
 ## 3. Optional: reverse-proxying scripts 
 
 This will only be necessary depending on which scripts you are using. The implementation will vary depending on hosting platform. See [Partytown's recommended guides](https://partytown.builder.io/proxying-requests#reverse-proxy).

--- a/docs/sveltekit.md
+++ b/docs/sveltekit.md
@@ -2,13 +2,14 @@
 title: SvelteKit
 ---
 
-SvelteKit does not offer any built in integrations, so we will add Partytown manually. Credit belongs to [monogram.io](https://monogram.io/blog/add-partytown-to-svelte) for this guide.
+SvelteKit does not offer any built in integrations, so we will add Partytown manually.
 
 1. Add the Partytown script to `src/routes/+layout.svelte`
 2. Copy the Partytown files to the local filesystem using the Vite plugin
-3. Reverse-Proxying scripts 
-4. Then adding 3rd party scripts
-
+3. Optional: reverse-proxying scripts
+4. Optional: `svelte-preprocess` configuration
+5. Then adding 3rd party scripts
+   
 ## 1. Add the Partytown script to `src/routes/+layout.svelte`
 
 Adapting from [the HTML integration guide](https://partytown.builder.io/html)
@@ -19,16 +20,6 @@ Adapting from [the HTML integration guide](https://partytown.builder.io/html)
 <script>
   import { onMount } from 'svelte'
   import { partytownSnippet } from '@builder.io/partytown/integration'
-
-  // Add the Partytown script to the DOM head
-  let scriptEl
-  onMount(
-    () => {
-      if (scriptEl) {
-        scriptEl.textContent = partytownSnippet()
-      }
-    }
-  )
 </script>
 
 <svelte:head>
@@ -40,8 +31,7 @@ Adapting from [the HTML integration guide](https://partytown.builder.io/html)
     }
   </script>
 
-  <!-- `partytownSnippet` is inserted here -->
-  <script bind:this={scriptEl}></script>
+  {@html '<script>' + partytownSnippet() + '</script>'}
 </svelte:head>
 ```
 
@@ -70,107 +60,56 @@ const config = {
 export default config
 ```
 
-## 3. Reverse-Proxying scripts 
+You will need to add `/static/~partytown` to your `.gitignore`.
 
-This will vary depending on hosting platform. See [Partytown's recommended guides](https://partytown.builder.io/proxying-requests#reverse-proxy).
+## 3. Optional: reverse-proxying scripts 
+
+This will only be necessary depending on which scripts you are using. The implementation will vary depending on hosting platform. See [Partytown's recommended guides](https://partytown.builder.io/proxying-requests#reverse-proxy).
+
+## 4. Optional: `svelte-preprocess` configuration
+
+Most users will be using `vitePreprocess` and will not need to update their `svelte.config.js` file. However, if you're are using `svelte-preprocess`, you will need to set the `preserve` option:
+```js
+// svelte.config.js
+
+const config = {
+  preprocess: preprocess({
+    preserve: ['partytown']
+  })
+  ...
+}
+```
+
+## 5. Then adding 3rd party scripts
+
+This is where we FINALLY use partytown to add those scripts (note `type="text/partytown"` below). This example shows Google Tag Manager. Putting it together with the previous changes, our `+layout.svelte` looks like:
 
 ```svelte
 // src/routes/+layout.svelte
 
 <script>
-  partytown = {
-    forward: ['dataLayer.push'],
-    resolveUrl: (url) => {
-      const siteUrl = 'https://monogram.io/proxytown'
-
-      if (url.hostname === 'www.googletagmanager.com') {
-        const proxyUrl = new URL(`${siteUrl}/gtm`)
-
-        const gtmId = new URL(url).searchParams.get('id')
-        gtmId && proxyUrl.searchParams.append('id', gtmId)
-
-        return proxyUrl
-      } else if (url.hostname === 'www.google-analytics.com') {
-        const proxyUrl = new URL(`${siteUrl}/ga`)
-
-        return proxyUrl
-      }
-
-      return url
-    }
-  }
+	import { partytownSnippet } from '@builder.io/partytown/integration'
 </script>
-```
 
-## 4. Then adding 3rd party scripts
-
-This is where we FINALLY use party town to add those scripts (note `type="text/partytown"` below). This example shows Google Tag Manager.
-
-```js
-// svelte.config.js
-
-const config = {
-  preprocess: [
-    preprocess({
-      preserve: ['partytown']
-    })
-  ],
-  ...
-}
-```
-
-and
-
-```svelte
-// src/routes/+layout.svelte
+<slot />
 
 <svelte:head>
-  <script>
-    // Config options
-    partytown = {
-      forward: ['dataLayer.push'],
-      resolveUrl: (url) => {
-        const siteUrl = 'https://example.com/proxytown'
+	<script>
+		partytown = {
+			forward: ['dataLayer.push']
+		};
+	</script>
 
-        if (url.hostname === 'www.googletagmanager.com') {
-          const proxyUrl = new URL(`${siteUrl}/gtm`)
+	{@html '<script>' + partytownSnippet() + '</script>'}
 
-          const gtmId = new URL(url).searchParams.get('id')
-          gtmId && proxyUrl.searchParams.append('id', gtmId)
-
-          return proxyUrl
-        } else if (
-          url.hostname === 'www.google-analytics.com'
-        ) {
-          const proxyUrl = new URL(`${siteUrl}/ga`)
-
-          return proxyUrl
-        }
-
-        return url
-      }
-    }
-  </script>
-  <!-- Insert `partytownSnippet` here -->
-  <script bind:this={scriptEl}></script>
-
-  <!-- GTM script + config -->
-  <script
-    type="text/partytown"
-    src="https://www.googletagmanager.com/gtag/js?id=YOUR-ID-HERE"></script>
-  <script type="text/partytown">
-    window.dataLayer = window.dataLayer || []
-
-    function gtag() {
-      dataLayer.push(arguments)
-    }
-
-    gtag('js', new Date())
-    gtag('config', 'YOUR-ID-HERE', {
-      page_path: window.location.pathname
-    })
-  </script>
+	<script type="text/partytown" src="https://www.googletagmanager.com/gtag/js?id=G-ZX7H2KPXNZ"></script>
+	<script type="text/partytown">
+		window.dataLayer = window.dataLayer || [];
+		function gtag(){dataLayer.push(arguments);}
+		gtag('js', new Date());
+		gtag('config', 'G-ZX7H2KPXNZ');
+	</script>
 </svelte:head>
 ```
 
-Reminder to visit https://monogram.io/blog/add-partytown-to-svelte if you need a blog-style guide on this.
+Acknowledgements: credit belongs to monogram.io for [an earlier version of this guide](https://monogram.io/blog/add-partytown-to-svelte).

--- a/docs/sveltekit.md
+++ b/docs/sveltekit.md
@@ -18,7 +18,6 @@ Adapting from [the HTML integration guide](https://partytown.builder.io/html)
 // src/routes/+layout.svelte
 
 <script>
-  import { onMount } from 'svelte'
   import { partytownSnippet } from '@builder.io/partytown/integration'
 </script>
 
@@ -35,9 +34,9 @@ Adapting from [the HTML integration guide](https://partytown.builder.io/html)
 </svelte:head>
 ```
 
-## 2. Copy the Partytown files to the local filesystem using the Vite plugin
+## 2. Copy the Partytown files to the local filesystem
 
-Adopting [this strategy](https://partytown.builder.io/copy-library-files#vite) from the Partytown+Vite docs:
+Adopting [this strategy](https://partytown.builder.io/copy-library-files#vite) from the Partytown + Vite docs:
 
 ```js
 // vite.config.js
@@ -51,8 +50,7 @@ const config = {
   plugins: [
     sveltekit(),
     partytownVite({
-      // `dest` specifies where files are copied to in production
-      dest: join(process.cwd(), 'static', '~partytown')
+      dest: join(process.cwd(), '.svelte-kit/output/client/~partytown')
     })
   ]
 }
@@ -60,7 +58,15 @@ const config = {
 export default config
 ```
 
-You will need to add `/static/~partytown` to your `.gitignore`.
+The above will handle `dev` mode. For `build`, you will need to update your `package.json`:
+```json
+// package.json
+{
+  "scripts": {
+    "build": "partytown copylib .svelte-kit/output/client/~partytown && vite build",
+  }
+}
+```
 
 ## 3. Optional: reverse-proxying scripts 
 

--- a/docs/sveltekit.md
+++ b/docs/sveltekit.md
@@ -2,7 +2,7 @@
 title: SvelteKit
 ---
 
-SvelteKit does not offer any built in integrations, so we will add Partytown manually.
+SvelteKit uses Vite to build, so we can use `partytownVite`.
 
 1. Add the Partytown script to `src/routes/+layout.svelte`
 2. Copy the Partytown files to the local filesystem using the Vite plugin
@@ -34,7 +34,7 @@ Adapting from [the HTML integration guide](https://partytown.builder.io/html)
 </svelte:head>
 ```
 
-## 2. Copy the Partytown files to the local filesystem
+## 2. Copy the Partytown files to the local filesystem using the Vite plugin
 
 Adopting [this strategy](https://partytown.builder.io/copy-library-files#vite) from the Partytown + Vite docs:
 


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [X] Docs / tests

# Description

Changes:
- `onMount` should not be used. It's called on document load. For the GA example, that's too late
- write the scripts to SvelteKit's output directory rather than the user's source directory
- Remove the reverse proxying example. It's extremely confusing to show a reverse proxy with for GA because it conflicts with [the GTM docs](https://partytown.builder.io/google-tag-manager), which say a reverse proxy is not necessary
- Clarify that one step refers to `svelte-preprocess`, which is generally no longer used

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
