### PR TITLE
Update integrations.md with correct Qwik URL

### DIFF
--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -10,7 +10,7 @@ Partytown can work with any HTML page, and doesn't require a specific framework.
 - [HTML](/html)
 - [NextJS](/nextjs)
 - [Nuxt](/nuxt)
-- [Qwik](https://qwik.builder.io/integrations/integration/partytown/)
+- [Qwik](https://qwik.builder.io/docs/integrations/partytown/)
 - [React](/react)
 - [Remix](/remix)
 - [Shopify Hydrogen](/shopify-hydrogen)


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

The URL to Qwik is broken on this page and goes to a 404. This MR updates that URL to the correct URL.

# Use cases and why

Current user experience:


![image](https://github.com/BuilderIO/partytown/assets/11149632/27076430-31d8-4ba5-b79f-222a24bfc366)


# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
