### PR TITLE
bug: Sleeknote - Promise not resolving correctly 

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -131,6 +131,7 @@
       <li><a href="/tests/integrations/mermaid/">Mermaid</a></li>
       <li><a href="/tests/integrations/twitter/">Twitter Embed</a></li>
       <li><a href="/tests/integrations/wistia/">Wistia</a></li>
+      <li><a href="/tests/integrations/sleeknote/">SleekNote</a></li>
     </ul>
 
     <hr />

--- a/tests/integrations/sleeknote/index.html
+++ b/tests/integrations/sleeknote/index.html
@@ -27,7 +27,7 @@
 
     <hr />
     <p><a href="/tests/integrations/sleeknote/standard.html">Standard Sleeknote</a></p>
-    <p><a href="https://sleeknote-js.github.io/sleeknote/">Sleeknote Docs</a></p>
+    <p><a href="https://help.sleeknote.com/hc/en-us/articles/6991176574621-What-cookies-does-Sleeknote-place-in-my-browser-">Sleeknote Cookie Docs</a></p>
     <p><a href="/tests/">All Tests</a></p>
   </body>
 </html>

--- a/tests/integrations/sleeknote/index.html
+++ b/tests/integrations/sleeknote/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Partytown Test Page" />
+
+    <title>SleekNote 🎉</title>
+
+    <script>
+      partytown = {
+        logCalls: true,
+        logGetters: true,
+        logSetters: true,
+        logImageRequests: true,
+        logMainAccess: true,
+        logSendBeaconRequests: true,
+        logStackTraces: false,
+        logScriptExecution: true,
+      };
+    </script>
+    <script src="/~partytown/debug/partytown.js"></script>
+    <script src="//sleeknotecustomerscripts.sleeknote.com/125947.js" type="text/partytown"></script>
+  </head>
+  <body>
+    <h1>SleekNote 🎉</h1>
+
+    <hr />
+    <p><a href="/tests/integrations/sleeknote/standard.html">Standard Sleeknote</a></p>
+    <p><a href="https://sleeknote-js.github.io/sleeknote/">Sleeknote Docs</a></p>
+    <p><a href="/tests/">All Tests</a></p>
+  </body>
+</html>

--- a/tests/integrations/sleeknote/sleeknote.spec.ts
+++ b/tests/integrations/sleeknote/sleeknote.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test('Sleeknote', async ({ page, browser }) => {
+  await page.goto('/tests/integrations/sleeknote/');
+  await page.waitForFunction(() => document.cookie.length > 0);
+
+  expect((await browser.contexts()[0].cookies()).find((o) => o.name === 'SNS')?.value).toEqual('1');
+});

--- a/tests/integrations/sleeknote/standard.html
+++ b/tests/integrations/sleeknote/standard.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Partytown Test Page" />
+
+    <title>SleekNote 🎉</title>
+    <script src="//sleeknotecustomerscripts.sleeknote.com/125947.js"></script>
+  </head>
+  <body>
+    <h1>SleekNote 🎉</h1>
+
+    <hr />
+    <p><a href="/tests/integrations/sleeknote/standard.html">Standard Sleeknote</a></p>
+    <p><a href="https://sleeknote-js.github.io/sleeknote/">Sleeknote Docs</a></p>
+    <p><a href="/tests/">All Tests</a></p>
+  </body>
+</html>


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description
Sleeknote is quite heavy on the CPU, which makes it a good contender for Partytown.
![image](https://github.com/BuilderIO/partytown/assets/408229/f667420f-1be3-45b4-b3f5-90eb3cb86f38)

It does however throw some errors from within the SleekNote code, because `event.data` is undefined.
It originates from within the SleekNote script:
```javascript
window.SleekNote.API = new Promise((resolve) =>
    window.addEventListener('sleekNote', (event) => {
        event.data.type == "load" && resolve(event.data.command);
    })
);
```
This is the errors that is logged:
![image](https://github.com/BuilderIO/partytown/assets/408229/02d1a78e-62b6-4824-ae5b-2f568b8382b0)



# Debugging
The debugging I did was setting a breakpoint where it threw, and then tried going back up the callstack, and set new breakpoints.
I can see that Sleeknote internally passes a promise around from Partytown, which seems like it dosent resolve correctly (ie. `event.data` being undefined).

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
