### PR TITLE
feat: fallback to Rollup/Vite output directory

### DIFF
--- a/docs/sveltekit.md
+++ b/docs/sveltekit.md
@@ -49,9 +49,7 @@ import { partytownVite } from '@builder.io/partytown/utils'
 const config = {
   plugins: [
     sveltekit(),
-    partytownVite({
-      dest: join(process.cwd(), '.svelte-kit/output/client/~partytown')
-    })
+    partytownVite()
   ]
 }
 


### PR DESCRIPTION
# What is it?

- [X] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Simplifies setting up Partytown

# Use cases and why

Users shouldn't have to specify the output directory a second time on top of specifying it in Rollup. For SvelteKit the output directory is considered an internal implementation detail which makes having to specify it even a bit more surprising

# Checklist:

- [X] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
