### PR TITLE
fix: preserve this inside addEventListener

### DIFF
--- a/src/lib/web-worker/worker-window.ts
+++ b/src/lib/web-worker/worker-window.ts
@@ -463,7 +463,7 @@ export const createWindow = (
         win.Worker = undefined;
       }
 
-      addEventListener(...args: any[]) {
+      addEventListener = (...args: any[]) => {
         if (args[0] === 'load') {
           if (env.$runWindowLoadEvent$) {
             setTimeout(() => args[1]({ type: 'load' }));

--- a/tests/platform/event/event.spec.ts
+++ b/tests/platform/event/event.spec.ts
@@ -58,4 +58,13 @@ test('events', async ({ page }) => {
   await page.waitForSelector('.testPreventDefault');
   const testPreventDefault = page.locator('#testPreventDefault');
   await expect(testPreventDefault).toHaveText('preventDefault-noop');
+
+  await page.locator('body').dblclick();
+
+  const testWinAddEventListenerNoContext = page.locator('#testWinAddEventListenerNoContext');
+  await expect(testWinAddEventListenerNoContext).toHaveText('Window dblclick');
+  const testWinAddEventListenerNoContextCount = page.locator(
+    '#testWinAddEventListenerNoContextCount'
+  );
+  await expect(testWinAddEventListenerNoContextCount).toHaveText('1');
 });

--- a/tests/platform/event/index.html
+++ b/tests/platform/event/index.html
@@ -116,6 +116,22 @@
       </li>
 
       <li>
+        <strong>(window.attachEvent || window.addEventListener)('dblclick')</strong>
+        <code id="testWinAddEventListenerNoContextCount">0</code>
+        <code id="testWinAddEventListenerNoContext"></code>
+        <script type="text/partytown">
+          (function () {
+            let count = 0;
+            (window.attachEvent || window.addEventListener)('dblclick', function (ev) {
+              document.getElementById('testWinAddEventListenerNoContextCount').textContent = ++count;
+              document.getElementById('testWinAddEventListenerNoContext').textContent =
+                this.constructor.name + ' ' + ev.type;
+            });
+          })();
+        </script>
+      </li>
+
+      <li>
         <strong>document.createEvent('Event')</strong>
         <code id="testCreateEvent" class="currentTarget"></code>
         <script type="text/partytown">


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

This will update addEventListener method to always have correct  `this` value, even when it's called without context.

# Use cases and why

While updating OneTrust service integration on our website to use Partytown, I've noticed that they are [using](https://cdn.cookielaw.org/scripttemplates/otSDKStub.js) addEventListener alongside window.attachEvent to support older versions of browsers.
<img width="698" alt="image" src="https://github.com/BuilderIO/partytown/assets/2673700/8409e278-5d3d-4ad8-a690-8714e0486d21">

The problem with the code they've written is that when addEventListener is called inside of WebWorker's addEventListener it has no context (`this === undefined`) and we get an error
<img width="1050" alt="image" src="https://github.com/BuilderIO/partytown/assets/2673700/8c6c250f-3ea9-4dd2-99c6-a3f44728655f">


Looks like we can easily update Partytown to support such cases by simply updating addEventListener to use arrow function (which preserves context).

P.S. `postMessage` method in this class has same problem, but I'm not sure whether we need to update as well, although I don't see any problems in doing so. I can update this PR to make it use arrow function if you think that it's a good idea.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
