### PR TITLE
feat: add document.scripts implementation

### DIFF
--- a/src/lib/web-worker/worker-document.ts
+++ b/src/lib/web-worker/worker-document.ts
@@ -175,6 +175,12 @@ export const patchDocument = (
       },
     },
 
+    scripts: {
+      get() {
+        return getter(this, ['scripts']);
+      },
+    },
+
     implementation: {
       get() {
         return {

--- a/tests/platform/document/document.spec.ts
+++ b/tests/platform/document/document.spec.ts
@@ -100,4 +100,10 @@ test('document', async ({ page }) => {
   const testImages = page.locator('#testDocumentImages');
   const pageUrl = new URL(page.url());
   await expect(testImages).toHaveText(`${pageUrl.origin}/fake.jpg`);
+
+  const testDocumentScriptsInitial = page.locator('#testDocumentScriptsInitial');
+  await expect(+(await testDocumentScriptsInitial.innerText())).toBeGreaterThan(0);
+  const value = +(await testDocumentScriptsInitial.innerText());
+  const testDocumentScriptsAfter = page.locator('#testDocumentScriptsAfter');
+  await expect(+(await testDocumentScriptsAfter.innerText())).toEqual(value + 1);
 });

--- a/tests/platform/document/index.html
+++ b/tests/platform/document/index.html
@@ -464,6 +464,25 @@
         </script>
       </li>
 
+      <li>
+        <strong>document.scripts</strong>
+        <code id="testDocumentScripts">
+          <span id="testDocumentScriptsInitial"></span>
+          <span id="testDocumentScriptsAfter"></span>
+        </code>
+        <script type="text/partytown">
+          (function () {
+            document.getElementById('testDocumentScriptsInitial').textContent = document.scripts.length;
+
+            const newScript = document.createElement('script');
+            newScript.innerText = `console.log("new script")`;
+            document.body.appendChild(newScript);
+
+            document.getElementById('testDocumentScriptsAfter').textContent = document.scripts.length;
+          })();
+        </script>
+      </li>
+
       <script type="text/partytown">
         (function () {
           document.body.classList.add('completed');


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Currently we get an error if we try to access document.scripts.length, this happens because document.scripts returns undefined. Example:
<img width="867" alt="document-scripts-issue" src="https://github.com/BuilderIO/partytown/assets/2673700/aaec2406-84ec-4587-82ab-3743256bb4f0">


# Use cases and why

Access to this scripts required by some 3rd party services that we use, for instance one of DoubleClick scripts
https://securepubads.g.doubleclick.net/pagead/managed/js/gpt/m202311090101/pubads_impl.js 

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality