### PR TITLE
feat: add image.removeEventListener implementation

### DIFF
--- a/src/lib/web-worker/worker-image.ts
+++ b/src/lib/web-worker/worker-image.ts
@@ -4,6 +4,8 @@ import { logWorker } from '../log';
 import { resolveUrl } from './worker-exec';
 import { webWorkerCtx } from './worker-constants';
 
+type HTMLImageElementEvents = 'load' | 'error';
+
 export const createImageConstructor = (env: WebWorkerEnvironment) =>
   class HTMLImageElement {
     s: string;
@@ -44,12 +46,21 @@ export const createImageConstructor = (env: WebWorkerEnvironment) =>
       );
     }
 
-    addEventListener(eventName: 'load' | 'error', cb: EventHandler) {
+    addEventListener(eventName: HTMLImageElementEvents, cb: EventHandler) {
       if (eventName === 'load') {
         this.l.push(cb);
       }
       if (eventName === 'error') {
         this.e.push(cb);
+      }
+    }
+
+    removeEventListener(eventName: HTMLImageElementEvents, cb: EventHandler) {
+      if (eventName === 'load') {
+        this.l = this.l.filter((fn) => fn !== cb);
+      }
+      if (eventName === 'error') {
+        this.e = this.e.filter((fn) => fn !== cb);
       }
     }
 

--- a/tests/platform/image/image.spec.ts
+++ b/tests/platform/image/image.spec.ts
@@ -3,8 +3,9 @@ import { test, expect } from '@playwright/test';
 test('image', async ({ page }) => {
   await page.goto('/tests/platform/image/');
 
-  const resolveUrlCalled = new Promise(resolve =>
-    page.on('request', request => request.url().includes('resolvedUrl') && resolve(true)));
+  const resolveUrlCalled = new Promise((resolve) =>
+    page.on('request', (request) => request.url().includes('resolvedUrl') && resolve(true))
+  );
 
   await page.waitForSelector('.testImageOnLoad');
   const testImageOnLoad = page.locator('#testImageOnLoad');
@@ -33,6 +34,11 @@ test('image', async ({ page }) => {
   await page.waitForSelector('.testImgListenerLoad');
   const testImgListenerLoad = page.locator('#testImgListenerLoad');
   await expect(testImgListenerLoad).toHaveText('load');
+
+  await page.waitForSelector('.testImgListenerRemoved');
+  const testImgListenerRemoved = page.locator('#testImgListenerRemoved');
+  await page.waitForTimeout(100);
+  await expect(testImgListenerRemoved).toHaveText('onload');
 
   await page.waitForSelector('.testImgListenerError');
   const testImgListenerError = page.locator('#testImgListenerError');

--- a/tests/platform/image/index.html
+++ b/tests/platform/image/index.html
@@ -175,6 +175,30 @@
       </li>
 
       <li>
+        <strong>&lt;img&gt; removeEventListener('load')</strong>
+        <code id="testImgListenerRemoved"></code>
+        <script type="text/partytown">
+          (function () {
+            const image = new Image();
+            const elm = document.getElementById('testImgListenerRemoved');
+
+            image.onload = function(){
+              elm.textContent = 'onload';
+            }
+
+            function handleImageLoad(ev) {
+              elm.textContent = ev.type;
+            }
+            image.addEventListener('load', handleImageLoad);
+            image.removeEventListener('load', handleImageLoad);
+            image.src = 'dot.gif?testImgListenerRemoved';
+
+            elm.className = 'testImgListenerRemoved';
+          })();
+        </script>
+      </li>
+
+      <li>
         <strong>&lt;img&gt; addEventListener('error')</strong>
         <code id="testImgListenerError"></code>
         <script type="text/partytown">


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

removeEventListener is missing on internal Image implementation, which can cause errors in some scenarios.
<img width="812" alt="image-remove-event-listener" src="https://github.com/BuilderIO/partytown/assets/2673700/aae36de8-b37c-4e92-ae93-df4e643ce11e">

# Use cases and why

Well, it's part of the spec, so it would be great if Partytown correctly handles this.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
