### PR TITLE
fix: add document.scripts & tests

### DIFF
--- a/src/lib/web-worker/worker-document.ts
+++ b/src/lib/web-worker/worker-document.ts
@@ -175,6 +175,12 @@ export const patchDocument = (
       },
     },
 
+    scripts: {
+      get() {
+        return getter(this, ['scripts']);
+      },
+    },
+
     implementation: {
       get() {
         return {

--- a/tests/platform/window/index.html
+++ b/tests/platform/window/index.html
@@ -769,6 +769,22 @@
         </script>
       </li>
 
+      <li>
+        <strong>Scripts</strong>
+        <code id="testDocumentScripts"></code>
+        <script type="text/partytown">
+          (function () {
+            const elm = document.getElementById('testDocumentScripts');
+            try{
+              const scripts = typeof window.document.scripts.length;
+              elm.textContent = 'scripts.length: ' + scripts;
+            }catch(e){
+              elm.textContent = e.toString();
+            }
+          })();
+        </script>
+      </li>
+
       <script type="text/partytown">
         (function () {
           document.body.classList.add('completed');

--- a/tests/platform/window/window.spec.ts
+++ b/tests/platform/window/window.spec.ts
@@ -154,4 +154,7 @@ test('window', async ({ page }) => {
 
   const testVisualViewport = page.locator('#testVisualViewport');
   await expect(testVisualViewport).toHaveText('scale:1 VisualViewport');
+
+  const testDocumentScripts = page.locator('#testDocumentScripts');
+  await expect(testDocumentScripts).toHaveText('scripts.length: number');
 });


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

`document.scripts` (or `window.document.scripts`) 

Accessing `document.scripts.length` triggers an error because `document.scripts` yields `undefined`. This issue arises from attempting to retrieve the length property of an undefined object, causing a code execution error in context of partytown workers.

# Use cases and why

Use case: we tried migrating Google publisher tag scripts into Partytown on our website (https://automobile.nau.ch/) and got following error:

![image](https://github.com/BuilderIO/partytown/assets/7689705/0fe7eb61-1cf5-4998-a86a-263b5463f7ce)
![image](https://github.com/BuilderIO/partytown/assets/7689705/d5ef411d-552d-4dc7-baab-40d053877265)

It can be reproduced by running any code that accesses the properties of `document.scripts` (or window.document.scripts) 

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
