### PR TITLE
docs: remove dangling code reference

### DIFF
--- a/docs/sveltekit.md
+++ b/docs/sveltekit.md
@@ -43,14 +43,6 @@ Adapting from [the HTML integration guide](https://partytown.builder.io/html)
 </script>
 
 <svelte:head>
-  <!-- Config options -->
-  <script>
-    // Forward the necessary functions to the web worker layer
-    partytown = {
-      forward: ['dataLayer.push']
-    }
-  </script>
-
   {@html '<script>' + partytownSnippet() + '</script>'}
 </svelte:head>
 ```
@@ -70,6 +62,7 @@ This is where we use partytown to add those scripts (note `type="text/partytown"
 
 <svelte:head>
 	<script>
+		// Forward the necessary functions to the web worker layer
 		partytown = {
 			forward: ['dataLayer.push']
 		};


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Setting `dataLayer.push` doesn't make sense until you have the Google Analytics script that uses it. Including it at this step could confuse users and make them think it's something everyone needs to do whether you use Google Analytics or not

<!--
# Use cases and why

 Actual / expected behavior if it's a bug 

- 1. One use case
- 2. Another use case
-->
# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality