### PR TITLE
feat: improve forwarding-events with `preserveBehavior`

### DIFF
--- a/docs/forwarding-events.md
+++ b/docs/forwarding-events.md
@@ -28,6 +28,32 @@ However, since GTM and Facebook Pixel were actually loaded in the web worker, th
 
 Notice the forward configs are just strings, not actual objects. We're using strings here so we can easily serialize what service variable was called, along with the function argument values. When the web worker receives the information, it then knows how to correctly apply the call and arguments that were fired from the main thread.
 
+You can customize each forwarded variable with the following settings:
+
+- ### preserveBehavior
+
+  In addition to the `forward` config, we also provide a `preserveBehavior` property. This property allows you to customize each forwarded property, preserving the original behavior of the function.
+
+  When `preserveBehavior` is set to `true`, the original function's behavior on the main thread is maintained, while also forwarding the calls to partytown. This is useful in cases where the function has side effects on the main thread that you want to keep.
+
+  If `preserveBehavior` is not explicitly set, its default value is `false`. This means that, by default, calls will only be forwarded to partytown and won't execute on the main thread.
+
+  Here's an example of how to use it:
+
+  ```js
+  <script>
+    partytown = {
+      forward: [
+        ['dataLayer.push', { preserveBehavior: true }],
+        ['fbq', { preserveBehavior: false }],
+        'gtm.push'
+      ]
+    };
+  </script>
+  ```
+
+  In this example, calls to `dataLayer.push` will execute as normal on the main thread and also be forwarded to partytown. Calls to `fbq` will only be forwarded to partytown, and won't execute on the main thread. For `gtm.push`, since preserveBehavior is not explicitly set, it will behave as if preserveBehavior was set to false, meaning it will only be forwarded to partytown.
+
 ## Integrations
 
 Please see the [Integrations](/integrations) section for examples using the `forward` config.

--- a/src/lib/main/snippet.ts
+++ b/src/lib/main/snippet.ts
@@ -1,4 +1,9 @@
-import { debug } from '../utils';
+import {
+  debug,
+  emptyObjectValue,
+  getOriginalBehavior,
+  resolvePartytownForwardProperty,
+} from '../utils';
 import type { MainWindow, PartytownConfig } from '../types';
 
 export function snippet(
@@ -12,7 +17,7 @@ export function snippet(
   timeout?: any,
   scripts?: NodeListOf<HTMLScriptElement>,
   sandbox?: HTMLIFrameElement | HTMLScriptElement,
-  mainForwardFn?: any,
+  mainForwardFn: typeof win = win,
   isReady?: number
 ) {
   // ES5 just so IE11 doesn't choke on arrow fns
@@ -103,7 +108,8 @@ export function snippet(
     // remove any previously patched functions
     if (top == win) {
       (config!.forward || []).map(function (forwardProps) {
-        delete win[forwardProps.split('.')[0] as any];
+        const { property } = resolvePartytownForwardProperty(forwardProps);
+        delete win[property.split('.')[0] as any];
       });
     }
 
@@ -135,17 +141,34 @@ export function snippet(
     // this is the top window
     // patch the functions that'll be forwarded to the worker
     (config.forward || []).map(function (forwardProps) {
+      const { property, preserveBehavior } = resolvePartytownForwardProperty(forwardProps);
       mainForwardFn = win;
-      forwardProps.split('.').map(function (_, i, forwardPropsArr) {
+      property.split('.').map(function (_, i, forwardPropsArr) {
         mainForwardFn = mainForwardFn[forwardPropsArr[i]] =
           i + 1 < forwardPropsArr.length
-            ? forwardPropsArr[i + 1] == 'push'
-              ? []
-              : mainForwardFn[forwardPropsArr[i]] || {}
-            : function () {
-                // queue these calls to be forwarded on later, after Partytown is ready
-                (win._ptf = win._ptf || []).push(forwardPropsArr, arguments);
-              };
+            ? mainForwardFn[forwardPropsArr[i]] || emptyObjectValue(forwardPropsArr[i + 1])
+            : (() => {
+                let originalFunction: ((...args: any[]) => any) | null = null;
+                if (preserveBehavior) {
+                  const { methodOrProperty, thisObject } = getOriginalBehavior(
+                    win,
+                    forwardPropsArr
+                  );
+                  if (typeof methodOrProperty === 'function') {
+                    originalFunction = (...args: any[]) =>
+                      methodOrProperty.apply(thisObject, ...args);
+                  }
+                }
+                return function () {
+                  let returnValue: any;
+                  if (originalFunction) {
+                    returnValue = originalFunction(arguments);
+                  }
+                  // queue these calls to be forwarded on later, after Partytown is ready
+                  (win._ptf = win._ptf || []).push(forwardPropsArr, arguments);
+                  return returnValue;
+                };
+              })();
       });
     });
   }

--- a/src/lib/main/snippet.ts
+++ b/src/lib/main/snippet.ts
@@ -108,7 +108,7 @@ export function snippet(
     // remove any previously patched functions
     if (top == win) {
       (config!.forward || []).map(function (forwardProps) {
-        const { property } = resolvePartytownForwardProperty(forwardProps);
+        const [property] = resolvePartytownForwardProperty(forwardProps);
         delete win[property.split('.')[0] as any];
       });
     }
@@ -141,7 +141,7 @@ export function snippet(
     // this is the top window
     // patch the functions that'll be forwarded to the worker
     (config.forward || []).map(function (forwardProps) {
-      const { property, preserveBehavior } = resolvePartytownForwardProperty(forwardProps);
+      const [property, { preserveBehavior }] = resolvePartytownForwardProperty(forwardProps);
       mainForwardFn = win;
       property.split('.').map(function (_, i, forwardPropsArr) {
         mainForwardFn = mainForwardFn[forwardPropsArr[i]] =

--- a/src/lib/sandbox/main-forward-trigger.ts
+++ b/src/lib/sandbox/main-forward-trigger.ts
@@ -1,4 +1,9 @@
-import { len } from '../utils';
+import {
+  emptyObjectValue,
+  getOriginalBehavior,
+  len,
+  resolvePartytownForwardProperty,
+} from '../utils';
 import { MainWindow, PartytownWebWorker, WinId, WorkerMessageType } from '../types';
 import { serializeForWorker } from './main-serialization';
 
@@ -6,7 +11,7 @@ export const mainForwardTrigger = (worker: PartytownWebWorker, $winId$: WinId, w
   let queuedForwardCalls = win._ptf;
   let forwards = (win.partytown || {}).forward || [];
   let i: number;
-  let mainForwardFn: any;
+  let mainForwardFn: typeof win;
 
   let forwardCall = ($forward$: string[], args: any) =>
     worker.postMessage([
@@ -21,12 +26,30 @@ export const mainForwardTrigger = (worker: PartytownWebWorker, $winId$: WinId, w
   win._ptf = undefined;
 
   forwards.map((forwardProps) => {
+    const { property, preserveBehavior } = resolvePartytownForwardProperty(forwardProps);
     mainForwardFn = win;
-    forwardProps.split('.').map((_, i, arr) => {
+    property.split('.').map((_, i, arr) => {
       mainForwardFn = mainForwardFn[arr[i]] =
         i + 1 < len(arr)
-          ? mainForwardFn[arr[i]] || (arr[i + 1] === 'push' ? [] : {})
-          : (...args: any) => forwardCall(arr, args);
+          ? mainForwardFn[arr[i]] || emptyObjectValue(arr[i + 1])
+          : (() => {
+              let originalFunction: ((...args: any[]) => any) | null = null;
+              if (preserveBehavior) {
+                const { methodOrProperty, thisObject } = getOriginalBehavior(win, arr);
+                if (typeof methodOrProperty === 'function') {
+                  originalFunction = (...args: any[]) =>
+                    methodOrProperty.apply(thisObject, ...args);
+                }
+              }
+              return (...args: any[]) => {
+                let returnValue: any;
+                if (originalFunction) {
+                  returnValue = originalFunction(args);
+                }
+                forwardCall(arr, args);
+                return returnValue;
+              };
+            })();
     });
   });
 

--- a/src/lib/sandbox/main-forward-trigger.ts
+++ b/src/lib/sandbox/main-forward-trigger.ts
@@ -26,7 +26,7 @@ export const mainForwardTrigger = (worker: PartytownWebWorker, $winId$: WinId, w
   win._ptf = undefined;
 
   forwards.map((forwardProps) => {
-    const { property, preserveBehavior } = resolvePartytownForwardProperty(forwardProps);
+    const [property, { preserveBehavior }] = resolvePartytownForwardProperty(forwardProps);
     mainForwardFn = win;
     property.split('.').map((_, i, arr) => {
       mainForwardFn = mainForwardFn[arr[i]] =

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -522,7 +522,11 @@ export interface PartytownConfig {
   nonce?: string;
 }
 
-export type PartytownForwardSettingsProperty = { property: string; preserveBehavior: boolean };
+export type PartytownForwardPropertySettings = {
+  preserveBehavior?: boolean;
+};
+
+export type PartytownForwardPropertyWithSettings = [string, PartytownForwardPropertySettings?];
 
 /**
  * A forward property to patch on `window`. The forward config property is an string,
@@ -532,7 +536,7 @@ export type PartytownForwardSettingsProperty = { property: string; preserveBehav
  *
  * @public
  */
-export type PartytownForwardProperty = string | PartytownForwardSettingsProperty;
+export type PartytownForwardProperty = string | PartytownForwardPropertyWithSettings;
 
 /**
  * @public

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -522,15 +522,17 @@ export interface PartytownConfig {
   nonce?: string;
 }
 
+export type PartytownForwardSettingsProperty = { property: string; preserveBehavior: boolean };
+
 /**
- * A foward property to patch on `window`. The foward config property is an string,
+ * A forward property to patch on `window`. The forward config property is an string,
  * representing the call to forward, such as `dataLayer.push` or `fbq`.
  *
  * https://partytown.builder.io/forwarding-events
  *
  * @public
  */
-export type PartytownForwardProperty = string;
+export type PartytownForwardProperty = string | PartytownForwardSettingsProperty;
 
 /**
  * @public
@@ -576,7 +578,11 @@ export interface ApplyHookOptions extends HookOptions {
   args: any[];
 }
 
-export interface MainWindow extends Window {
+export type StringIndexable = {
+  [key: string]: any;
+};
+
+export interface MainWindow extends Window, StringIndexable {
   partytown?: PartytownConfig;
   _ptf?: any[];
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,7 +2,8 @@ import type {
   ApplyPath,
   MainWindow,
   PartytownForwardProperty,
-  PartytownForwardSettingsProperty,
+  PartytownForwardPropertySettings,
+  PartytownForwardPropertyWithSettings,
   RandomId,
   StringIndexable,
 } from './types';
@@ -145,16 +146,19 @@ export const isValidUrl = (url: any): boolean => {
   }
 };
 
+const defaultPartytownForwardPropertySettings: Required<PartytownForwardPropertySettings> = {
+  preserveBehavior: false,
+};
+
 export const resolvePartytownForwardProperty = (
-  property: PartytownForwardProperty
-): PartytownForwardSettingsProperty => {
-  if (typeof property === 'string') {
-    return {
-      property,
-      preserveBehavior: false,
-    };
+  propertyOrPropertyWithSettings: PartytownForwardProperty
+): Required<PartytownForwardPropertyWithSettings> => {
+  if (typeof propertyOrPropertyWithSettings === 'string') {
+    return [propertyOrPropertyWithSettings, defaultPartytownForwardPropertySettings];
   }
-  return property;
+  const [property, settings = defaultPartytownForwardPropertySettings] =
+    propertyOrPropertyWithSettings;
+  return [property, { ...defaultPartytownForwardPropertySettings, ...settings }];
 };
 
 type GetOriginalBehaviorReturn = {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,11 @@
-import type { ApplyPath, RandomId } from './types';
+import type {
+  ApplyPath,
+  MainWindow,
+  PartytownForwardProperty,
+  PartytownForwardSettingsProperty,
+  RandomId,
+  StringIndexable,
+} from './types';
 
 export const debug = !!(globalThis as any).partytownDebug;
 
@@ -136,4 +143,61 @@ export const isValidUrl = (url: any): boolean => {
   } catch (_) {
     return false;
   }
+};
+
+export const resolvePartytownForwardProperty = (
+  property: PartytownForwardProperty
+): PartytownForwardSettingsProperty => {
+  if (typeof property === 'string') {
+    return {
+      property,
+      preserveBehavior: false,
+    };
+  }
+  return property;
+};
+
+type GetOriginalBehaviorReturn = {
+  thisObject: StringIndexable;
+  methodOrProperty: Function | Record<string, unknown> | undefined;
+};
+
+export const getOriginalBehavior = (
+  window: MainWindow,
+  properties: string[]
+): GetOriginalBehaviorReturn => {
+  let thisObject: StringIndexable = window;
+
+  for (let i = 0; i < properties.length - 1; i += 1) {
+    thisObject = thisObject[properties[i]];
+  }
+
+  return {
+    thisObject,
+    methodOrProperty:
+      properties.length > 0 ? thisObject[properties[properties.length - 1]] : undefined,
+  };
+};
+
+const getMethods = (obj: {} | []): string[] => {
+  const properties = new Set<string>();
+  let currentObj: any = obj;
+  do {
+    Object.getOwnPropertyNames(currentObj).forEach((item) => {
+      if (typeof currentObj[item] === 'function') {
+        properties.add(item);
+      }
+    });
+  } while ((currentObj = Object.getPrototypeOf(currentObj)) !== Object.prototype);
+  return Array.from(properties);
+};
+
+const arrayMethods = Object.freeze(getMethods([]));
+
+export const emptyObjectValue = (propertyName: string): [] | {} => {
+  if (arrayMethods.includes(propertyName)) {
+    return [];
+  }
+
+  return {};
 };

--- a/tests/integrations/event-forwarding/event-forwarding.spec.ts
+++ b/tests/integrations/event-forwarding/event-forwarding.spec.ts
@@ -10,15 +10,45 @@ test('integration event forwarding', async ({ page }) => {
   const testArray = page.locator('#testArray');
   await expect(testArray).toHaveText('arrayReady');
 
+  const testPreservedArray = page.locator('#testPreservedArray');
+  await expect(testPreservedArray).toHaveText('arrayReady');
+
   const buttonForwardEvent = page.locator('#buttonForwardEvent');
   await buttonForwardEvent.click();
   await expect(testFn).toHaveText('click1');
   await buttonForwardEvent.click();
   await expect(testFn).toHaveText('click2');
 
+  const windowHandle = await page.evaluateHandle(() => Promise.resolve(window));
+
+  const superArrayHandle = await page.evaluateHandle(
+    (window) => window['superArray'] as Record<string, unknown>[],
+    windowHandle
+  );
   const buttonArrayPush = page.locator('#buttonArrayPush');
   await buttonArrayPush.click();
   await expect(testArray).toHaveText(JSON.stringify({ mph: 88 }));
   await buttonArrayPush.click();
   await expect(testArray).toHaveText(JSON.stringify({ mph: 89 }));
+  const superArray = await superArrayHandle.jsonValue();
+  await superArrayHandle.dispose();
+  await expect(superArray).toStrictEqual([]);
+
+  const superPreservedArrayHandle = await page.evaluateHandle(
+    (window) => window['superPreservedArray'] as Record<string, unknown>[],
+    windowHandle
+  );
+  const buttonPreservedArrayPush = page.locator('#buttonPreservedArrayPush');
+  const label = page.locator('#testPreservedArrayReturnValue');
+  await buttonPreservedArrayPush.click();
+  await expect(testPreservedArray).toHaveText(JSON.stringify({ mph: 88 }));
+  await expect(label).toHaveText('2');
+  await buttonPreservedArrayPush.click();
+  await expect(testPreservedArray).toHaveText(JSON.stringify({ mph: 89 }));
+  await expect(label).toHaveText('3');
+  const superPreservedArray = await superPreservedArrayHandle.jsonValue();
+  await superPreservedArrayHandle.dispose();
+  await expect(superPreservedArray).toStrictEqual([{ mph: 89 }, { mph: 88 }, 'arrayReady']);
+
+  await windowHandle.dispose();
 });

--- a/tests/integrations/event-forwarding/index.html
+++ b/tests/integrations/event-forwarding/index.html
@@ -12,7 +12,7 @@
           'superDuperFunction',
           'superArray.push',
           'KiwiSizing',
-          { property: 'superPreservedArray.unshift', preserveBehavior: true },
+          ['superPreservedArray.unshift', { preserveBehavior: true }],
         ],
         logCalls: true,
         logGetters: true,

--- a/tests/integrations/event-forwarding/index.html
+++ b/tests/integrations/event-forwarding/index.html
@@ -8,7 +8,12 @@
 
     <script>
       partytown = {
-        forward: ['superDuperFunction', 'superArray.push','KiwiSizing'],
+        forward: [
+          'superDuperFunction',
+          'superArray.push',
+          'KiwiSizing',
+          { property: 'superPreservedArray.unshift', preserveBehavior: true },
+        ],
         logCalls: true,
         logGetters: true,
         logSetters: true,
@@ -21,6 +26,7 @@
     <script>
       superDuperFunction('fnReady');
       superArray.push('arrayReady');
+      superPreservedArray.unshift('arrayReady');
     </script>
 
     <script type="text/partytown">
@@ -64,7 +70,29 @@
       })();
     </script>
 
-    <script type='text/partytown'>
+    <script type="text/partytown">
+      (function() {
+        const testArray = document.getElementById('testPreservedArray');
+        const label = document.getElementById('testPreservedArrayReturnValue');
+
+        superPreservedArray = [];
+        superPreservedArray.unshift = function() {
+          switch (arguments[0]) {
+            case 'arrayReady': {
+              testArray.textContent = arguments[0];
+              label.textContent = 1;
+              break;
+            }
+            default: {
+              testArray.textContent = JSON.stringify(arguments[0]);
+              break;
+            }
+          }
+        }
+      })();
+    </script>
+
+    <script type="text/partytown">
       (function () {
         window.KiwiSizing = window.KiwiSizing === undefined ? {} : window.KiwiSizing;
         KiwiSizing.data = {
@@ -78,9 +106,9 @@
     <script type="text/partytown">
       console.log("KiwiSizing", KiwiSizing)
       console.log("KiwiSizing.data", KiwiSizing.data)
-      window.document.getElementById("kiwisizing").innerText = KiwiSizing.data;
+      window.document.getElementById("kiwisizing").innerText = JSON.stringify(KiwiSizing.data);
     </script>
-      <style>
+    <style>
       body {
         font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif,
           Apple Color Emoji, Segoe UI Emoji;
@@ -112,6 +140,7 @@
       }
       li strong,
       li code,
+      li span,
       li button {
         white-space: nowrap;
         flex: 1;
@@ -146,6 +175,24 @@
             const btn = document.getElementById('buttonArrayPush');
             btn.addEventListener('click', function (ev) {
               superArray.push({ mph: mph++ });
+            });
+          })();
+        </script>
+      </li>
+      <li>
+        <strong>array unshift event with preserve behavior</strong>
+        <button id="buttonPreservedArrayPush">unshift</button>
+        <span>
+          <code id="testPreservedArray"></code>
+          <code id="testPreservedArrayReturnValue"></code>
+        </span>
+        <script>
+          (function () {
+            let mph = 88;
+            const btn = document.getElementById('buttonPreservedArrayPush');
+            const label = document.getElementById('testPreservedArrayReturnValue');
+            btn.addEventListener('click', function (ev) {
+              label.textContent = superPreservedArray.unshift({ mph: mph++ });
             });
           })();
         </script>

--- a/tests/integrations/gtm/gtm.spec.ts
+++ b/tests/integrations/gtm/gtm.spec.ts
@@ -10,4 +10,36 @@ test('gtm', async ({ page }) => {
 
   const testDataLayer = page.locator('#testDataLayer');
   await expect(testDataLayer).toHaveText('pushed');
+
+  const windowHandle = await page.evaluateHandle(() => Promise.resolve(window));
+  const dataLayerHandle = await page.evaluateHandle(
+    (window) => window['dataLayer'] as Record<string, unknown>[],
+    windowHandle
+  );
+  const dataLayer = await dataLayerHandle.jsonValue();
+  expect(dataLayer).toStrictEqual([]);
+  await dataLayerHandle.dispose();
+  await windowHandle.dispose();
+});
+
+test('gtm with preserveBehavior', async ({ page }) => {
+  await page.goto('/tests/integrations/gtm/preserve-behavior.html');
+
+  await page.waitForSelector('.completed');
+
+  const buttonDataLayerPush = page.locator('#buttonDataLayerPush');
+  await buttonDataLayerPush.click();
+
+  const testDataLayer = page.locator('#testDataLayer');
+  await expect(testDataLayer).toHaveText('pushed');
+
+  const windowHandle = await page.evaluateHandle(() => Promise.resolve(window));
+  const dataLayerHandle = await page.evaluateHandle(
+    (window) => window['dataLayer'] as Record<string, unknown>[],
+    windowHandle
+  );
+  const dataLayer = await dataLayerHandle.jsonValue();
+  expect(dataLayer).toStrictEqual([{ event: 'button-click', from: 'partytown' }]);
+  await dataLayerHandle.dispose();
+  await windowHandle.dispose();
 });

--- a/tests/integrations/gtm/preserve-behavior.html
+++ b/tests/integrations/gtm/preserve-behavior.html
@@ -21,7 +21,7 @@
 
           return url;
         },
-        forward: [{ property: 'dataLayer.push', preserveBehavior: true }],
+        forward: [['dataLayer.push', { preserveBehavior: true }]],
         logCalls: true,
         logGetters: true,
         logSetters: true,

--- a/tests/integrations/gtm/preserve-behavior.html
+++ b/tests/integrations/gtm/preserve-behavior.html
@@ -21,7 +21,7 @@
 
           return url;
         },
-        forward: ['dataLayer.push'],
+        forward: [{ property: 'dataLayer.push', preserveBehavior: true }],
         logCalls: true,
         logGetters: true,
         logSetters: true,
@@ -123,12 +123,8 @@
       })();
     </script>
 
+    <p><a href="/tests/integrations/gtm/">Partytown GTM</a></p>
     <p><a href="/tests/integrations/gtm/standard.html">Standard GTM</a></p>
-    <p>
-      <a href="/tests/integrations/gtm/preserve-behavior.html"
-        >Partytown GTM with preserveBehavior</a
-      >
-    </p>
     <p><a href="/tests/">All Tests</a></p>
   </body>
 </html>

--- a/tests/integrations/gtm/standard.html
+++ b/tests/integrations/gtm/standard.html
@@ -86,6 +86,11 @@
 
     <hr />
     <p><a href="/tests/integrations/gtm/">Partytown GTM</a></p>
+    <p>
+      <a href="/tests/integrations/gtm/preserve-behavior.html"
+        >Partytown GTM with preserveBehavior</a
+      >
+    </p>
     <p><a href="/tests/">All Tests</a></p>
   </body>
 </html>


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

This PR adds the ability to preserve the behavior of forwarded functions. This comes in candy for some scenarios, for example, some third parties integrations that monitor the global `dataLayer` array in order to work. When GA is handled by partytown the array will be empty, this new functionality allows to keep the events there.

Even if the motivation for this is GA and the dataLayer array, this would work for any other forwarded method, as it makes the trick including a call to the original method in the patched version (in fact, in the tests added there is a case where the forwarded method is `unshift` instead of `push`).

If you want to enable this new setting, you would do it like this:
`forward: ['simpleProperty', ['dataLayer.push', { preserveBehavior: true }]],`
I also contemplated the possibility of doing so:
`forward: ['simpleProperty', { property: 'dataLayer.push', preserveBehavior: true }],`
but I prefer the first way. Anyway I'm open to implement any other way of doing it.

# Use cases and why

- 1. GA integration, as described above.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation (not yet)
- [x] Added new tests to cover the fix / functionality

If you think this PR is worth, I could add the documentation of the new setting.
Waiting for your feedback, thank you!
