### PR TITLE
feat: access missing navigator properties

### DIFF
--- a/src/lib/web-worker/worker-navigator.ts
+++ b/src/lib/web-worker/worker-navigator.ts
@@ -3,10 +3,10 @@ import { debug } from '../utils';
 import { logWorker } from '../log';
 import { resolveUrl } from './worker-exec';
 import { webWorkerCtx } from './worker-constants';
+import { getter } from './worker-proxy';
 
 export const createNavigator = (env: WebWorkerEnvironment) => {
-  let key: any;
-  let nav: any = {
+  const nav: any = {
     sendBeacon: (url: string, body?: any) => {
       if (debug && webWorkerCtx.$config$.logSendBeaconRequests) {
         try {
@@ -34,7 +34,7 @@ export const createNavigator = (env: WebWorkerEnvironment) => {
     },
   };
 
-  for (key in navigator) {
+  for (let key in navigator) {
     nav[key] = (navigator as any)[key];
   }
 
@@ -42,6 +42,13 @@ export const createNavigator = (env: WebWorkerEnvironment) => {
     set(_, propName, propValue) {
       (navigator as any)[propName] = propValue;
       return true;
+    },
+    get(target, prop) {
+      if (Object.prototype.hasOwnProperty.call(target, prop)) {
+        return target[prop];
+      }
+      const value = getter(env.$window$, ['navigator', prop]);
+      return value;
     },
   });
 };

--- a/tests/platform/navigator/index.html
+++ b/tests/platform/navigator/index.html
@@ -95,6 +95,31 @@
           })();
         </script>
       </li>
+      <li>
+        <strong>Properties defined in global navigator but not in the worker instance</strong>
+        <code id="testMainNavigatorProperties"></code>
+        <script type="text/partytown">
+          (function () {
+            const elm = document.getElementById('testMainNavigatorProperties');
+            navigator.undefinedProp = undefined;
+            navigator.nullProp = null;
+            navigator.falseProp = false;
+            navigator.emptyStringProp = "";
+            elm.textContent = JSON.stringify({
+              javaEnabled: navigator.javaEnabled(),
+              cookieEnabled: navigator.cookieEnabled,
+              undefinedProp: navigator.undefinedProp ? 'is_defined' : 'is_undefined',
+              nullProp: navigator.nullProp,
+              falseProp: navigator.falseProp,
+              emptyStringProp: navigator.emptyStringProp,
+              newProperty: navigator.newProperty ? 'is_defined' : 'is_undefined',
+              pdfViewerEnabled: typeof navigator.pdfViewerEnabled === 'boolean' ? 'available' : 'undefined',
+              plugins: typeof navigator.plugins.length === 'number' ? 'available' : 'undefined',
+            });
+            elm.className = 'testMainNavigatorProperties';
+          })();
+        </script>
+      </li>
     </ul>
 
     <hr />

--- a/tests/platform/navigator/navigator.spec.ts
+++ b/tests/platform/navigator/navigator.spec.ts
@@ -14,4 +14,10 @@ test('navigator', async ({ page }) => {
   await page.waitForSelector('.testNavKey');
   const testNavKey = page.locator('#testNavKey');
   await expect(testNavKey).toContainText('5');
+
+  await page.waitForSelector('.testMainNavigatorProperties');
+  const testMainNavigatorProperties = page.locator('#testMainNavigatorProperties');
+  await expect(testMainNavigatorProperties).toContainText(
+    '{"javaEnabled":false,"cookieEnabled":true,"undefinedProp":"is_undefined","nullProp":null,"falseProp":false,"emptyStringProp":"","newProperty":"is_undefined","pdfViewerEnabled":"available","plugins":"available"}'
+  );
 });


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

Some third party integration we have tries to access a navigator's property that is defined in the top-level navigator ([Navigator](https://developer.mozilla.org/en-US/docs/Web/API/Navigator)) instance but not in the worker navigator ([WorkerNavigator](https://developer.mozilla.org/en-US/docs/Web/API/WorkerNavigator)).

In my case the properties are `javaEnabled` and `cookieEnabled`.

This should fix #414 and  #270 

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
