### PR TITLE
fix: loadScriptsOnMainThread breaks when using a regexp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ node_modules/
 /index.d.ts
 .idea
 .history
+tests/integrations/load-scripts-on-main-thread/snippet.js

--- a/scripts/build-integration.ts
+++ b/scripts/build-integration.ts
@@ -15,6 +15,11 @@ export function buildIntegration(opts: BuildOptions): RollupOptions {
       file: join(opts.distIntegrationDir, 'index.mjs'),
       format: 'es',
     },
+    {
+      file: join(opts.testsDir, 'integrations', 'load-scripts-on-main-thread', 'snippet.js'),
+      format: 'umd',
+      name: 'partytownIntegration',
+    },
   ];
 
   return {

--- a/src/integration/index.ts
+++ b/src/integration/index.ts
@@ -16,6 +16,8 @@ export { SCRIPT_TYPE } from '../lib/utils';
 export type {
   PartytownConfig,
   PartytownForwardProperty,
+  PartytownForwardPropertyWithSettings,
+  PartytownForwardPropertySettings,
   ApplyHook,
   GetHook,
   SetHook,

--- a/src/integration/snippet.ts
+++ b/src/integration/snippet.ts
@@ -1,17 +1,10 @@
+import { serializeConfig } from '../lib/utils';
 import type { PartytownConfig } from '../lib/types';
 
 export const createSnippet = (config: PartytownConfig | undefined | null, snippetCode: string) => {
   const { forward = [], ...filteredConfig } = config || {};
 
-  const configStr = JSON.stringify(filteredConfig, (k, v) => {
-    if (typeof v === 'function') {
-      v = String(v);
-      if (v.startsWith(k + '(')) {
-        v = 'function ' + v;
-      }
-    }
-    return v;
-  });
+  const configStr = serializeConfig(filteredConfig);
 
   return [
     `!(function(w,p,f,c){`,

--- a/src/lib/sandbox/read-main-platform.ts
+++ b/src/lib/sandbox/read-main-platform.ts
@@ -5,6 +5,7 @@ import {
   isValidMemberName,
   len,
   noop,
+  serializeConfig,
 } from '../utils';
 import { config, docImpl, libPath, mainWindow } from './main-globals';
 import {
@@ -61,15 +62,7 @@ export const readMainPlatform = () => {
     readImplementation('Node', textNode),
   ];
 
-  const $config$ = JSON.stringify(config, (k, v) => {
-    if (typeof v === 'function') {
-      v = String(v);
-      if (v.startsWith(k + '(')) {
-        v = 'function ' + v;
-      }
-    }
-    return v;
-  });
+  const $config$ = serializeConfig(config);
 
   const initWebWorkerData: InitWebWorkerData = {
     $config$,

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -157,7 +157,7 @@ export type InterfaceMember =
 
 export interface WebWorkerContext {
   $asyncMsgTimer$?: any;
-  $config$: PartytownConfig;
+  $config$: PartytownInternalConfig;
   $importScripts$: (...urls: string[]) => void;
   $initWindowMedia$?: InitWindowMedia;
   $interfaces$: InterfaceInfo[];
@@ -522,6 +522,10 @@ export interface PartytownConfig {
   nonce?: string;
 }
 
+export type PartytownInternalConfig = Omit<PartytownConfig, 'loadScriptsOnMainThread'> & {
+  loadScriptsOnMainThread?: ['regexp' | 'string', string][];
+};
+
 export type PartytownForwardPropertySettings = {
   preserveBehavior?: boolean;
 };
@@ -715,6 +719,7 @@ export interface WorkerInstance {
 }
 
 export interface WorkerNode extends WorkerInstance, Node {
+  id?: string | undefined | null;
   type: string | undefined;
 }
 

--- a/src/lib/web-worker/init-web-worker.ts
+++ b/src/lib/web-worker/init-web-worker.ts
@@ -4,11 +4,12 @@ import {
   webWorkerlocalStorage,
   webWorkerSessionStorage,
 } from './worker-constants';
-import type { InitWebWorkerData } from '../types';
-import type { PartytownConfig } from '@builder.io/partytown/integration';
+import type { InitWebWorkerData, PartytownInternalConfig } from '../types';
 
 export const initWebWorker = (initWebWorkerData: InitWebWorkerData) => {
-  const config: PartytownConfig = (webWorkerCtx.$config$ = JSON.parse(initWebWorkerData.$config$));
+  const config: PartytownInternalConfig = (webWorkerCtx.$config$ = JSON.parse(
+    initWebWorkerData.$config$
+  ));
   const locOrigin = initWebWorkerData.$origin$;
   webWorkerCtx.$importScripts$ = importScripts.bind(self);
   webWorkerCtx.$interfaces$ = initWebWorkerData.$interfaces$;
@@ -24,9 +25,11 @@ export const initWebWorker = (initWebWorkerData: InitWebWorkerData) => {
   delete (self as any).postMessage;
   delete (self as any).WorkerGlobalScope;
 
-  (commaSplit('resolveUrl,get,set,apply') as any).map((configName: keyof PartytownConfig) => {
-    if (config[configName]) {
-      config[configName] = new Function('return ' + config[configName])();
+  (commaSplit('resolveUrl,get,set,apply') as any).map(
+    (configName: keyof PartytownInternalConfig) => {
+      if (config[configName]) {
+        config[configName] = new Function('return ' + config[configName])();
+      }
     }
-  });
+  );
 };

--- a/src/lib/web-worker/worker-node.ts
+++ b/src/lib/web-worker/worker-node.ts
@@ -16,7 +16,12 @@ import {
   webWorkerCtx,
   WinIdKey,
 } from './worker-constants';
-import { defineConstructorName, SCRIPT_TYPE, SCRIPT_TYPE_EXEC } from '../utils';
+import {
+  defineConstructorName,
+  SCRIPT_TYPE,
+  SCRIPT_TYPE_EXEC,
+  testIfMustLoadScriptOnMainThread,
+} from '../utils';
 import { getInstanceStateValue } from './worker-state';
 import { insertIframe, runScriptContent } from './worker-exec';
 import { isScriptJsType } from './worker-script';
@@ -59,7 +64,7 @@ export const createNodeCstr = (
               // @ts-ignore
               const scriptId = newNode.id;
               const loadOnMainThread =
-                scriptId && config.loadScriptsOnMainThread?.includes?.(scriptId);
+                scriptId && testIfMustLoadScriptOnMainThread(config, scriptId);
 
               if (loadOnMainThread) {
                 setter(newNode, ['type'], 'text/javascript');

--- a/src/lib/web-worker/worker-script.ts
+++ b/src/lib/web-worker/worker-script.ts
@@ -1,4 +1,4 @@
-import { definePrototypePropertyDescriptor } from '../utils';
+import { definePrototypePropertyDescriptor, testIfMustLoadScriptOnMainThread } from '../utils';
 import { getInstanceStateValue, setInstanceStateValue } from './worker-state';
 import { getter, setter } from './worker-proxy';
 import { HTMLSrcElementDescriptorMap } from './worker-src-element';
@@ -26,10 +26,8 @@ export const patchHTMLScriptElement = (WorkerHTMLScriptElement: any, env: WebWor
           setter(this, ['dataset', 'ptsrc'], orgUrl);
         }
 
-        if (this.type && config.loadScriptsOnMainThread) {
-          const shouldExecuteScriptViaMainThread = config.loadScriptsOnMainThread.some(
-            (scriptUrl) => new RegExp(scriptUrl).test(url)
-          );
+        if (this.type) {
+          const shouldExecuteScriptViaMainThread = testIfMustLoadScriptOnMainThread(config, url);
 
           if (shouldExecuteScriptViaMainThread) {
             setter(this, ['type'], 'text/javascript');

--- a/tests/integrations/load-scripts-on-main-thread/background-test-script.js
+++ b/tests/integrations/load-scripts-on-main-thread/background-test-script.js
@@ -1,0 +1,4 @@
+(() => {
+  self.backgroundTestScriptRanInTheBackgroundFlag = self.name !== '';
+  document.body.classList.add('background-completed');
+})();

--- a/tests/integrations/load-scripts-on-main-thread/load-scripts-on-main-thread.spec.ts
+++ b/tests/integrations/load-scripts-on-main-thread/load-scripts-on-main-thread.spec.ts
@@ -1,14 +1,53 @@
 import { test, expect } from '@playwright/test';
 
 test('integration window accessor', async ({ page }) => {
-  await page.goto('/tests/integrations/load-scripts-on-main-thread/');
-  await page.waitForSelector('.completed');
+  await page.goto('/tests/integrations/load-scripts-on-main-thread/index.html');
+  await page.waitForSelector('.completed.regexp-completed.background-completed');
 
   const scriptElement = page.locator('#testScript');
-  await expect(scriptElement).toHaveAttribute('type', 'text/javascript')
+  await expect(scriptElement).toHaveAttribute('type', 'text/javascript');
+  const testScriptRanInTheBackground = page.locator('#testScriptRanInTheBackground');
+  await expect(testScriptRanInTheBackground).toHaveText('false');
 
   const regexScriptElement = page.locator('#regexTestScript');
-  await expect(regexScriptElement).toHaveAttribute('type', 'text/javascript')
+  await expect(regexScriptElement).toHaveAttribute('type', 'text/javascript');
+  const regexTestScriptRanInTheBackground = page.locator('#regexTestScriptRanInTheBackground');
+  await expect(regexTestScriptRanInTheBackground).toHaveText('false');
+
+  const inlineTestScriptRanInTheBackground = page.locator('#inlineTestScriptRanInTheBackground');
+  await expect(inlineTestScriptRanInTheBackground).toHaveText('false');
+
+  const backgroundTestScriptRanInTheBackground = page.locator(
+    '#backgroundTestScriptRanInTheBackground'
+  );
+  await expect(backgroundTestScriptRanInTheBackground).toHaveText('true');
+
+  await page.waitForSelector('.testInlineScript');
+  const testInlineScript = page.locator('#testInlineScript');
+  await expect(testInlineScript).toHaveText('12');
+});
+
+test('integration window accessor with snippet', async ({ page }) => {
+  await page.goto('/tests/integrations/load-scripts-on-main-thread/snippet.html');
+  await page.waitForSelector('.completed.regexp-completed.background-completed');
+
+  const scriptElement = page.locator('#testScript');
+  await expect(scriptElement).toHaveAttribute('type', 'text/javascript');
+  const testScriptRanInTheBackground = page.locator('#testScriptRanInTheBackground');
+  await expect(testScriptRanInTheBackground).toHaveText('false');
+
+  const regexScriptElement = page.locator('#regexTestScript');
+  await expect(regexScriptElement).toHaveAttribute('type', 'text/javascript');
+  const regexTestScriptRanInTheBackground = page.locator('#regexTestScriptRanInTheBackground');
+  await expect(regexTestScriptRanInTheBackground).toHaveText('false');
+
+  const inlineTestScriptRanInTheBackground = page.locator('#inlineTestScriptRanInTheBackground');
+  await expect(inlineTestScriptRanInTheBackground).toHaveText('false');
+
+  const backgroundTestScriptRanInTheBackground = page.locator(
+    '#backgroundTestScriptRanInTheBackground'
+  );
+  await expect(backgroundTestScriptRanInTheBackground).toHaveText('true');
 
   await page.waitForSelector('.testInlineScript');
   const testInlineScript = page.locator('#testInlineScript');

--- a/tests/integrations/load-scripts-on-main-thread/regex-test-script.js
+++ b/tests/integrations/load-scripts-on-main-thread/regex-test-script.js
@@ -1,3 +1,4 @@
 (() => {
-    document.body.classList.add('completed');
-})()
+  self.regexTestScriptRanInTheBackgroundFlag = self.name !== '';
+  document.body.classList.add('regexp-completed');
+})();

--- a/tests/integrations/load-scripts-on-main-thread/snippet.html
+++ b/tests/integrations/load-scripts-on-main-thread/snippet.html
@@ -5,9 +5,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="Partytown Test Page" />
     <title>Load scripts on main thread</title>
+    <script src="./snippet.js"></script>
 
     <script>
-      partytown = {
+      const config = partytownIntegration.partytownSnippet({
         logCalls: true,
         logGetters: true,
         logSetters: true,
@@ -18,9 +19,12 @@
           `inline-test-script`,
           /regex-test-script\.js/,
         ],
-      };
+      });
+      const script = document.createElement('script');
+      script.type = 'text/javascript';
+      script.innerHTML = config;
+      document.head.appendChild(script);
     </script>
-    <script src="/~partytown/debug/partytown.js"></script>
     <script type="text/partytown">
       (() => {
         const scriptElement = document.createElement("script");
@@ -177,19 +181,6 @@
         </script>
       </li>
       <li>
-        <strong>Partytown Config:</strong>
-        <code id="testConfig"></code>
-        <script>
-          (() => {
-            const partyTownConfig = window.partytown;
-            const codeElement = document.getElementById('testConfig');
-
-            codeElement.innerText = partyTownConfig.loadScriptsOnMainThread;
-          })();
-        </script>
-      </li>
-
-      <li>
         <strong>Inline script</strong>
         <code id="testInlineScript"></code>
         <script type="text/javascript">
@@ -249,8 +240,8 @@
 
     <hr />
     <p>
-      <a href="/tests/integrations/load-scripts-on-main-thread/snippet.html"
-        >loadScriptsOnMainThread with snippet</a
+      <a href="/tests/integrations/load-scripts-on-main-thread/index.html"
+        >Standard loadScriptsOnMainThread</a
       >
     </p>
     <p><a href="/tests/">All Tests</a></p>

--- a/tests/integrations/load-scripts-on-main-thread/test-script.js
+++ b/tests/integrations/load-scripts-on-main-thread/test-script.js
@@ -1,3 +1,4 @@
 (() => {
-    document.body.classList.add('completed');
-})()
+  self.testScriptRanInTheBackgroundFlag = self.name !== '';
+  document.body.classList.add('completed');
+})();

--- a/tests/integrations/load-scripts-on-main-thread/wait-for-class.js
+++ b/tests/integrations/load-scripts-on-main-thread/wait-for-class.js
@@ -1,0 +1,19 @@
+export function waitForClass(element, className) {
+  return new Promise((resolve) => {
+    const observer = new MutationObserver((mutations) => {
+      mutations.forEach((mutation) => {
+        if (mutation.attributeName === 'class') {
+          const currentClassState =
+            mutation.target instanceof HTMLElement
+              ? mutation.target.classList.contains(className)
+              : false;
+          if (currentClassState) {
+            observer.disconnect();
+            resolve();
+          }
+        }
+      });
+    });
+    observer.observe(element, { attributes: true });
+  });
+}

--- a/tests/unit/utils.ts
+++ b/tests/unit/utils.ts
@@ -2,6 +2,7 @@ import { suite as uvuSuite } from 'uvu';
 import type {
   MainWindow,
   PartytownConfig,
+  PartytownInternalConfig,
   PartytownWebWorker,
   WebWorkerEnvironment,
   WinId,
@@ -73,7 +74,7 @@ export interface TestContext {
   location: Location;
   loc: any;
   worker: TestWorker;
-  config: PartytownConfig;
+  config: PartytownInternalConfig;
   env: WebWorkerEnvironment;
   snippetCode: string;
   run: (code: string) => any;


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

This PR fixes two issues with loadScriptsOnMainThread:

- When using a regexp in loadScriptsOnMainThread all scripts will be executed in the main thread, even if their url doesn't match the regexp.
- If a string is used and it includes some characters reserved by regexp (such as interrogation marks), even if the script src seems to match, the script won't be executed in the main thread.

You can check the issue if you execute the new tests added (checking out the first commit of the PR) without the fix included in the PR (second commit).
I added new tests in `tests/integrations/load-scripts-on-main-thread` to display whether the scripts in the page have been executed on the main thread or in the background. In addition I added a new script, `background-test-script.js` that should be executed in the background since is not included in `loadScriptsOnMainThread`. If you execute the test before the fix is applied this is what is displayed:

<img width="1397" alt="Screenshot 2024-01-26 at 14 03 41" src="https://github.com/BuilderIO/partytown/assets/85033117/04340872-4630-4b2e-a1d3-f88e12480eff">

The script is executed on the main thread but it shouldn't. After the fix we get the expected behavior:

<img width="1298" alt="Screenshot 2024-01-26 at 14 04 20" src="https://github.com/BuilderIO/partytown/assets/85033117/0874b847-be73-48d4-9e0f-d9dbb1b7e2fb">


- The main problem in the first issue is: when the config is serialised using `JSON.stringify` https://github.com/BuilderIO/partytown/blob/486b5a9df92dad22137bd0e07b8deeb6f9c2e8c5/src/lib/sandbox/read-main-platform.ts#L64 the regexp [gets serialised unexpectedly](https://stackoverflow.com/questions/20276531/stringifying-a-regular-expression) as an empty object. Once this empty object is used to create a RegExp object it will match any string.

- For the second issue since the string provided is used to create a RegExp https://github.com/BuilderIO/partytown/blob/486b5a9df92dad22137bd0e07b8deeb6f9c2e8c5/src/lib/web-worker/worker-script.ts#L31, if it contains a regexp wildcard/operator (such as dots or question marks) it will be handled as those regexp operators and wildcards instead of an actual character. If this is the case, in most cases (when the resulting regexp is not equivalent to the one expected) the regexp won't match the url to test.

In the solution I provide the regexp is serialised using its `source` property, and `loadScriptsOnMainThread` itself with this type `[type: 'string' | 'regexp', value: string][]`. So if we have these values:

```typescript
loadScriptsOnMainThread = [/.*mywebsite\.com/, 'https://www.anotherawesomewebsite.com/resource'];
```

the property will be serialised and used internally as:

```typescript
loadScriptsOnMainThread = [
  ['regexp', '/.*mywebsite.com/'],
  ['string', 'https://www.anotherawesomewebsite.com/resource'],
];
```

Note that the type of the public property won't change.

This way we can know beforehand if the string provided is a plain string (that will be escaped when creating the regexp) or a regexp source (and won't be escaped). Therefore, internally the prop will be used as you would expect:

```typescript
loadScriptsOnMainThread = [
  /.*mywebsite.com/,
  /https:\/\/www\.anotherawesomewebsite\.com\/resource/,
];
```

It would be great to discuss and apply any suggestion 😄

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality