### PR TITLE
0.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@builder.io/partytown",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Relocate resource intensive third-party scripts off of the main thread and into a web worker.",
   "license": "MIT",
   "main": "index.cjs",


### PR DESCRIPTION
- fix: loadScriptsOnMainThread breaks when using a regexp (#540)  3bb8e9b
- feat: access missing navigator properties (#539)  486b5a9

https://github.com/BuilderIO/partytown/compare/v0.9.0...v0.9.1