### PR TITLE
fix: proxy localStorage and sessionStorage (closes #293)

### DIFF
--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -16,8 +16,8 @@ import {
 } from './web-worker/worker-constants';
 import { debug, getConstructorName, isPromise } from './utils';
 
-export const warnCrossOrgin = (
-  apiType: 'get' | 'set' | 'remove' | 'clear',
+export const warnCrossOrigin = (
+  apiType: 'get' | 'set' | 'remove' | 'clear' | 'length' | 'key',
   apiName: string,
   env: WebWorkerEnvironment
 ) => console.warn(`Partytown unable to ${apiType} cross-origin ${apiName}: ` + env.$location$);

--- a/src/lib/sandbox/read-main-platform.ts
+++ b/src/lib/sandbox/read-main-platform.ts
@@ -3,7 +3,6 @@ import {
   getConstructorName,
   getNodeName,
   isValidMemberName,
-  len,
   noop,
   serializeConfig,
 } from '../utils';
@@ -13,7 +12,6 @@ import {
   InterfaceInfo,
   InterfaceMember,
   InitWebWorkerData,
-  StorageItem,
 } from '../types';
 
 export const readMainPlatform = () => {
@@ -68,9 +66,7 @@ export const readMainPlatform = () => {
     $config$,
     $interfaces$: readImplementations(impls, initialInterfaces),
     $libPath$: new URL(libPath, mainWindow.location as any) + '',
-    $origin$: origin,
-    $localStorage$: readStorage('localStorage'),
-    $sessionStorage$: readStorage('sessionStorage'),
+    $origin$: origin
   };
 
   addGlobalConstructorUsingPrototype(
@@ -184,18 +180,6 @@ const readImplementationMember = (
   } catch (e) {
     console.warn(e);
   }
-};
-
-const readStorage = (storageName: 'localStorage' | 'sessionStorage') => {
-  let items: StorageItem[] = [];
-  let i = 0;
-  let l = len(mainWindow[storageName]);
-  let key: string;
-  for (; i < l; i++) {
-    key = mainWindow[storageName].key(i)!;
-    items.push([key, mainWindow[storageName].getItem(key)!]);
-  }
-  return items;
 };
 
 const getGlobalConstructor = (mainWindow: any, cstrName: string) =>

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -127,8 +127,6 @@ export interface InitWebWorkerData {
   $interfaces$: InterfaceInfo[];
   $libPath$: string;
   $sharedDataBuffer$?: SharedArrayBuffer;
-  $localStorage$: StorageItem[];
-  $sessionStorage$: StorageItem[];
   $origin$: string;
 }
 
@@ -638,8 +636,6 @@ export type RefHandler = (...args: any[]) => void;
 export type StateMap = Record<number, StateRecord>;
 
 export type StateRecord = Record<string | number, any>;
-
-export type StorageItem = [/*key*/ string, /*value*/ string];
 
 export const enum CallType {
   Blocking = 1,

--- a/src/lib/web-worker/init-web-worker.ts
+++ b/src/lib/web-worker/init-web-worker.ts
@@ -1,8 +1,6 @@
 import {
   commaSplit,
   webWorkerCtx,
-  webWorkerlocalStorage,
-  webWorkerSessionStorage,
 } from './worker-constants';
 import type { InitWebWorkerData, PartytownInternalConfig } from '../types';
 
@@ -17,9 +15,6 @@ export const initWebWorker = (initWebWorkerData: InitWebWorkerData) => {
   webWorkerCtx.$origin$ = locOrigin;
   webWorkerCtx.$postMessage$ = (postMessage as any).bind(self);
   webWorkerCtx.$sharedDataBuffer$ = initWebWorkerData.$sharedDataBuffer$;
-
-  webWorkerlocalStorage.set(locOrigin, initWebWorkerData.$localStorage$);
-  webWorkerSessionStorage.set(locOrigin, initWebWorkerData.$sessionStorage$);
 
   (self as any).importScripts = undefined;
   delete (self as any).postMessage;

--- a/src/lib/web-worker/worker-constants.ts
+++ b/src/lib/web-worker/worker-constants.ts
@@ -4,7 +4,6 @@ import type {
   PostMessageData,
   RefHandler,
   RefId,
-  StorageItem,
   WebWorkerContext,
   WebWorkerEnvironment,
   WinId,
@@ -27,10 +26,6 @@ export const postMessages: PostMessageData[] = [];
 
 export const webWorkerCtx: WebWorkerContext = {} as any;
 export const webWorkerInterfaces: InterfaceInfo[] = [];
-
-export const webWorkerlocalStorage = /*#__PURE__*/ new Map<string, StorageItem[]>();
-export const webWorkerSessionStorage = /*#__PURE__*/ new Map<string, StorageItem[]>();
-
 export const environments: { [winId: WinId]: WebWorkerEnvironment } = {};
 
 export const cachedDimensions = /*#__PURE__*/ new Map<string, any>();

--- a/src/lib/web-worker/worker-document.ts
+++ b/src/lib/web-worker/worker-document.ts
@@ -20,7 +20,7 @@ import { ABOUT_BLANK, elementStructurePropNames, IS_TAG_REG, WinIdKey } from './
 import { getInstanceStateValue } from './worker-state';
 import { getPartytownScript } from './worker-exec';
 import { isScriptJsType } from './worker-script';
-import { warnCrossOrgin } from '../log';
+import { warnCrossOrigin } from '../log';
 
 export const patchDocument = (
   WorkerDocument: any,
@@ -39,7 +39,7 @@ export const patchDocument = (
         if (env.$isSameOrigin$) {
           return getter(this, ['cookie']);
         } else {
-          warnCrossOrgin('get', 'cookie', env);
+          warnCrossOrigin('get', 'cookie', env);
           return '';
         }
       },
@@ -47,7 +47,7 @@ export const patchDocument = (
         if (env.$isSameOrigin$) {
           setter(this, ['cookie'], value);
         } else if (debug) {
-          warnCrossOrgin('set', 'cookie', env);
+          warnCrossOrigin('set', 'cookie', env);
         }
       },
     },

--- a/src/lib/web-worker/worker-storage.ts
+++ b/src/lib/web-worker/worker-storage.ts
@@ -1,74 +1,61 @@
-import { callMethod } from './worker-proxy';
-import { CallType, StorageItem, WebWorkerEnvironment } from '../types';
+import { callMethod, getter } from './worker-proxy';
+import { CallType, WebWorkerEnvironment } from '../types';
 import { EMPTY_ARRAY } from '../utils';
-import { warnCrossOrgin } from '../log';
+import { warnCrossOrigin } from '../log';
 
 export const addStorageApi = (
   win: any,
   storageName: 'localStorage' | 'sessionStorage',
-  storages: Map<string, StorageItem[]>,
   isSameOrigin: boolean,
   env: WebWorkerEnvironment
 ) => {
-  let getItems = (items?: StorageItem[]) => {
-    items = storages.get(win.origin);
-    if (!items) {
-      storages.set(win.origin, (items = []));
-    }
-    return items;
-  };
-  let getIndexByKey = (key: string) => getItems().findIndex((i) => i[STORAGE_KEY] === key);
-  let index: number;
-  let item: StorageItem;
-
   let storage: Storage = {
     getItem(key) {
-      index = getIndexByKey(key);
-      return index > -1 ? getItems()[index][STORAGE_VALUE] : null;
+      if (isSameOrigin) {
+        return callMethod(win, [storageName, 'getItem'], [key], CallType.Blocking);
+      } else {
+        warnCrossOrigin('get', storageName, env);
+      }
     },
 
     setItem(key, value) {
-      index = getIndexByKey(key);
-      if (index > -1) {
-        getItems()[index][STORAGE_VALUE] = value;
-      } else {
-        getItems().push([key, value]);
-      }
       if (isSameOrigin) {
-        callMethod(win, [storageName, 'setItem'], [key, value], CallType.NonBlocking);
+        callMethod(win, [storageName, 'setItem'], [key, value], CallType.Blocking);
       } else {
-        warnCrossOrgin('set', storageName, env);
+        warnCrossOrigin('set', storageName, env);
       }
     },
 
     removeItem(key) {
-      index = getIndexByKey(key);
-      if (index > -1) {
-        getItems().splice(index, 1);
-      }
       if (isSameOrigin) {
-        callMethod(win, [storageName, 'removeItem'], [key], CallType.NonBlocking);
+        callMethod(win, [storageName, 'removeItem'], [key], CallType.Blocking);
       } else {
-        warnCrossOrgin('remove', storageName, env);
+        warnCrossOrigin('remove', storageName, env);
       }
     },
 
     key(index) {
-      item = getItems()[index];
-      return item ? item[STORAGE_KEY] : null;
+      if (isSameOrigin) {
+        return callMethod(win, [storageName, 'key'], [index], CallType.Blocking);
+      } else {
+        warnCrossOrigin('key', storageName, env);
+      }
     },
 
     clear() {
-      getItems().length = 0;
       if (isSameOrigin) {
-        callMethod(win, [storageName, 'clear'], EMPTY_ARRAY, CallType.NonBlocking);
+        callMethod(win, [storageName, 'clear'], EMPTY_ARRAY, CallType.Blocking);
       } else {
-        warnCrossOrgin('clear', storageName, env);
+        warnCrossOrigin('clear', storageName, env);
       }
     },
 
     get length() {
-      return getItems().length;
+      if (isSameOrigin) {
+        return getter(win, [storageName, 'length'])
+      } else {
+        warnCrossOrigin('length', storageName, env);
+      }
     },
   };
 
@@ -99,6 +86,3 @@ export const addStorageApi = (
     },
   });
 };
-
-const STORAGE_KEY = 0;
-const STORAGE_VALUE = 1;

--- a/src/lib/web-worker/worker-window.ts
+++ b/src/lib/web-worker/worker-window.ts
@@ -25,8 +25,6 @@ import {
   NamespaceKey,
   postMessages,
   webWorkerCtx,
-  webWorkerlocalStorage,
-  webWorkerSessionStorage,
   WinIdKey,
 } from './worker-constants';
 import { createCustomElementRegistry } from './worker-custom-elements';
@@ -419,8 +417,8 @@ export const createWindow = (
         win.cancelIdleCallback = (id: number) => clearTimeout(id);
 
         // add storage APIs to the window
-        addStorageApi(win, 'localStorage', webWorkerlocalStorage, $isSameOrigin$, env);
-        addStorageApi(win, 'sessionStorage', webWorkerSessionStorage, $isSameOrigin$, env);
+        addStorageApi(win, 'localStorage', $isSameOrigin$, env);
+        addStorageApi(win, 'sessionStorage', $isSameOrigin$, env);
 
         if (!$isSameOrigin$) {
           win.indexeddb = undefined;

--- a/tests/platform/storage/storage-access.html
+++ b/tests/platform/storage/storage-access.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="Partytown Test Page" />
+  <title>Storage</title>
+  <style>
+      body {
+          font-family: -apple-system, BlinkMacSystemFont, Segoe UI, Helvetica, Arial, sans-serif,
+          Apple Color Emoji, Segoe UI Emoji;
+          font-size: 12px;
+      }
+      h1 {
+          margin: 0 0 15px 0;
+      }
+      ul {
+          list-style-type: none;
+          margin: 0;
+          padding: 0;
+      }
+      a {
+          display: block;
+          padding: 16px 8px;
+      }
+      a:link,
+      a:visited {
+          text-decoration: none;
+          color: blue;
+      }
+      a:hover {
+          background-color: #eee;
+      }
+      li {
+          display: flex;
+          margin: 15px 0;
+      }
+      li strong,
+      li code,
+      li button {
+          white-space: nowrap;
+          flex: 1;
+          margin: 0 5px;
+      }
+  </style>
+  <script>
+    partytown = {
+      logCalls: true,
+      logGetters: true,
+      logSetters: true,
+      logStackTraces: false,
+      logScriptExecution: true,
+      get: params => {
+        if (params.constructor === 'Window' && params.name === 'sessionStorage.length') {
+          return 10
+        }
+        if (params.constructor === 'Window' && params.name === 'localStorage.length') {
+          return 13
+        }
+        return params.continue
+      },
+      apply: params => {
+        console.log(params.name)
+        if (params.constructor === 'Window' && [
+          'sessionStorage.getItem',
+          'localStorage.getItem',
+          'sessionStorage.setItem',
+          'localStorage.setItem',
+          'sessionStorage.removeItem',
+          'localStorage.removeItem',
+          'sessionStorage.clear',
+          'localStorage.clear',
+          'sessionStorage.key',
+          'localStorage.key',
+        ].includes(params.name)) {
+          return `mocked ${params.name}`
+        }
+        return params.continue
+      },
+    };
+  </script>
+  <script src="/~partytown/debug/partytown.js"></script>
+  <script>
+    localStorage.clear();
+    sessionStorage.clear();
+
+    localStorage.setItem('dmc', '12');
+    sessionStorage.setItem('mph', '88')
+  </script>
+</head>
+<body>
+<h1>Storage</h1>
+<ul>
+  <li>
+    <strong>Local storage size</strong>
+    <code id="localStorageSize"></code>
+    <script type="text/partytown">
+      (function () {
+        const size = localStorage.length;
+        const elm = document.getElementById('localStorageSize');
+        elm.textContent = size;
+      })();
+    </script>
+  </li>
+
+  <li>
+    <strong>Local storage getItem</strong>
+    <code id="localStorageItem"></code>
+    <script type="text/partytown">
+      (function () {
+        const item = localStorage.getItem('dmc');
+        const elm = document.getElementById('localStorageItem');
+        elm.textContent = item;
+      })();
+    </script>
+  </li>
+
+  <li>
+    <strong>Local storage setItem</strong>
+    <script type="text/partytown">
+      (function () {
+        localStorage.setItem('dmc', '9999');
+      })();
+    </script>
+  </li>
+
+  <li>
+    <strong>Local storage removeItem</strong>
+    <script type="text/partytown">
+      (function () {
+        localStorage.removeItem('dmc');
+      })();
+    </script>
+  </li>
+
+  <li>
+    <strong>Local storage clear</strong>
+    <script type="text/partytown">
+      (function () {
+        localStorage.clear();
+      })();
+    </script>
+  </li>
+
+  <li>
+    <strong>Local storage key</strong>
+    <code id="localStorageKey"></code>
+    <script type="text/partytown">
+      (function () {
+        const item = localStorage.key(0);
+        const elm = document.getElementById('localStorageKey');
+        elm.textContent = item;
+      })();
+    </script>
+  </li>
+
+  <li>
+    <strong>Session storage size</strong>
+    <code id="sessionStorageSize"></code>
+    <script type="text/partytown">
+      (function () {
+        const size = sessionStorage.length;
+        const elm = document.getElementById('sessionStorageSize');
+        elm.textContent = size;
+      })();
+    </script>
+  </li>
+
+  <li>
+    <strong>Session storage getItem</strong>
+    <code id="sessionStorageItem"></code>
+    <script type="text/partytown">
+      (function () {
+        const item = sessionStorage.getItem('mph');
+        const elm = document.getElementById('sessionStorageItem');
+        elm.textContent = item;
+      })();
+    </script>
+  </li>
+
+  <li>
+    <strong>Session storage setItem</strong>
+    <script type="text/partytown">
+      (function () {
+        sessionStorage.setItem('mph', '9999');
+      })();
+    </script>
+  </li>
+
+  <li>
+    <strong>Session storage removeItem</strong>
+    <script type="text/partytown">
+      (function () {
+        sessionStorage.removeItem('mph');
+      })();
+    </script>
+  </li>
+
+  <li>
+    <strong>Session storage clear</strong>
+    <script type="text/partytown">
+      (function () {
+        sessionStorage.clear();
+      })();
+    </script>
+  </li>
+
+  <li>
+    <strong>Session storage key</strong>
+    <code id="sessionStorageKey"></code>
+    <script type="text/partytown">
+      (function () {
+        const item = sessionStorage.key(0);
+        const elm = document.getElementById('sessionStorageKey');
+        elm.textContent = item;
+      })();
+    </script>
+  </li>
+
+  <script type="text/partytown">
+    (function () {
+      document.body.classList.add('completed');
+    })();
+  </script>
+</ul>
+
+<hr />
+<p><a href="/tests/">All Tests</a></p>
+</body>
+</html>

--- a/tests/platform/storage/storage-access.spec.ts
+++ b/tests/platform/storage/storage-access.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from '@playwright/test';
+
+test('storage access', async ({ page }) => {
+  await page.goto('/tests/platform/storage/storage-access.html');
+
+  await page.waitForSelector('.completed');
+
+  const testLocalStorageSize = page.locator('#localStorageSize');
+  await expect(testLocalStorageSize).toHaveText('13');
+
+  const testLocalStorageGetItem = page.locator('#localStorageItem');
+  await expect(testLocalStorageGetItem).toHaveText('mocked localStorage.getItem');
+
+  // @ts-expect-error localStorage exists on the page
+  const realLocalStorageItem = await page.evaluate(() => localStorage.getItem('dmc'))
+  expect(realLocalStorageItem).toBe('12');
+
+  const testLocalStorageKey = page.locator('#localStorageKey');
+  await expect(testLocalStorageKey).toHaveText('mocked localStorage.key');
+
+  const testSessionStorageSize = page.locator('#sessionStorageSize');
+  await expect(testSessionStorageSize).toHaveText('10');
+
+  const testSessionStorageGetItem = page.locator('#sessionStorageItem');
+  await expect(testSessionStorageGetItem).toHaveText('mocked sessionStorage.getItem');
+
+  // @ts-expect-error sessionStorage exists on the page
+  const realSessionStorageItem = await page.evaluate(() => sessionStorage.getItem('mph'))
+  expect(realSessionStorageItem).toBe('88');
+
+  const testSessionStorageKey = page.locator('#sessionStorageKey');
+  await expect(testSessionStorageKey).toHaveText('mocked sessionStorage.key');
+});


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

In the current implementation, we cache both storages (localStorage and sessionStorage) at the moment of worker creation. Although this could be considered as performance optimization, it leads to the implementation inconsistency:
- Storage data leaks into 3rd party script
- Storages easily go out of sync as there is no proper synchronization with main window setup.
- One can not override the storage access easily.

For the latter point, this means we can not take on the methods like `localStorage.getItem()` in the Partytown proxy methods (specifically in `apply`). Hence there is no way to shield the storage data from 3rd party scripts.

In this commit we fully rely on the storage values the main window sends into the worker. As the result, we can always receive relevant value and also can override the storage api with `apply` and `get` hooks

# Use cases and why

- Block accessing the localStorage: 
```
    <script>
      partytown = {
        apply: opts => {
          if ('localStorage.getItem' === opts.name) {
			return null; // Block localStorage access
		  }
          return opts.continue;
        }
      };
    </script>
```

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality


##### Before

<img width="1377" alt="image" src="https://github.com/BuilderIO/partytown/assets/46719800/126d7ccf-34f3-40c4-b03b-f2baf1edc1b5">


##### After

<img width="1397" alt="image" src="https://github.com/BuilderIO/partytown/assets/46719800/5c64ec61-8e38-4ea7-a48f-2c1bd6f6f69b">
