### PR TITLE
feat: add sendBeacon request parameters hook

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -383,7 +383,10 @@ export type ResolveUrlType = 'fetch' | 'xhr' | 'script' | 'iframe' | 'image';
 /**
  * @public
  */
-export type SendBeaconParameters = Pick<RequestInit, 'keepalive' | 'mode' | 'headers' | 'signal' | 'cache'>;
+export type SendBeaconParameters = Pick<
+  RequestInit,
+  'keepalive' | 'mode' | 'headers' | 'signal' | 'cache'
+>;
 
 /**
  * https://partytown.builder.io/configuration
@@ -411,7 +414,10 @@ export interface PartytownConfig {
    * @param location - The current window location.
    * @returns The returned value must be a SendBeaconParameters interface, otherwise the default parameters are used.
    */
-  resolveSendBeaconRequestParameters?(url: URL, location: Location): SendBeaconParameters | undefined | null;
+  resolveSendBeaconRequestParameters?(
+    url: URL,
+    location: Location
+  ): SendBeaconParameters | undefined | null;
   /**
    * When set to `true`, Partytown scripts are not inlined and not minified.
    *

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -381,6 +381,11 @@ export type SerializedInstance =
 export type ResolveUrlType = 'fetch' | 'xhr' | 'script' | 'iframe' | 'image';
 
 /**
+ * @public
+ */
+export type SendBeaconParameters = Pick<RequestInit, 'keepalive' | 'mode' | 'headers' | 'signal' | 'cache'>;
+
+/**
  * https://partytown.builder.io/configuration
  *
  * @public
@@ -398,6 +403,15 @@ export interface PartytownConfig {
    * @returns The returned value must be a URL interface, otherwise the default resolved URL is used.
    */
   resolveUrl?(url: URL, location: Location, type: ResolveUrlType): URL | undefined | null;
+  /**
+   * The `resolveSendBeaconRequestParameters()` hook can be used to modify the RequestInit parameters
+   * being used by the fetch request that polyfills the navigator.sendBeacon API in the worker context.
+   *
+   * @param url - The URL to be resolved. This is a URL https://developer.mozilla.org/en-US/docs/Web/API/URL, not a string.
+   * @param location - The current window location.
+   * @returns The returned value must be a SendBeaconParameters interface, otherwise the default parameters are used.
+   */
+  resolveSendBeaconRequestParameters?(url: URL, location: Location): SendBeaconParameters | undefined | null;
   /**
    * When set to `true`, Partytown scripts are not inlined and not minified.
    *

--- a/src/lib/web-worker/init-web-worker.ts
+++ b/src/lib/web-worker/init-web-worker.ts
@@ -1,7 +1,4 @@
-import {
-  commaSplit,
-  webWorkerCtx,
-} from './worker-constants';
+import { commaSplit, webWorkerCtx } from './worker-constants';
 import type { InitWebWorkerData, PartytownInternalConfig } from '../types';
 
 export const initWebWorker = (initWebWorkerData: InitWebWorkerData) => {
@@ -20,7 +17,7 @@ export const initWebWorker = (initWebWorkerData: InitWebWorkerData) => {
   delete (self as any).postMessage;
   delete (self as any).WorkerGlobalScope;
 
-  (commaSplit('resolveUrl,get,set,apply') as any).map(
+  (commaSplit('resolveUrl,resolveSendBeaconRequestParameters,get,set,apply') as any).map(
     (configName: keyof PartytownInternalConfig) => {
       if (config[configName]) {
         config[configName] = new Function('return ' + config[configName])();

--- a/src/lib/web-worker/worker-exec.ts
+++ b/src/lib/web-worker/worker-exec.ts
@@ -223,7 +223,7 @@ const resolveBaseLocation = (env: WebWorkerEnvironment, baseLocation?: Location)
     }
   }
   return baseLocation;
-}
+};
 
 export const resolveToUrl = (
   env: WebWorkerEnvironment,
@@ -233,9 +233,8 @@ export const resolveToUrl = (
   resolvedUrl?: URL,
   configResolvedUrl?: any
 ) => {
-  
   baseLocation = resolveBaseLocation(env, baseLocation);
-  
+
   resolvedUrl = new URL(url || '', baseLocation as any);
   if (type && webWorkerCtx.$config$.resolveUrl) {
     configResolvedUrl = webWorkerCtx.$config$.resolveUrl!(resolvedUrl, baseLocation, type!);
@@ -253,13 +252,16 @@ export const resolveSendBeaconRequestParameters = (env: WebWorkerEnvironment, ur
   const baseLocation = resolveBaseLocation(env);
   const resolvedUrl = new URL(url || '', baseLocation as any);
   if (webWorkerCtx.$config$.resolveSendBeaconRequestParameters) {
-    const configResolvedParams = webWorkerCtx.$config$.resolveSendBeaconRequestParameters!(resolvedUrl, baseLocation);
+    const configResolvedParams = webWorkerCtx.$config$.resolveSendBeaconRequestParameters!(
+      resolvedUrl,
+      baseLocation
+    );
     if (configResolvedParams) {
       return configResolvedParams;
     }
   }
   return {};
-}
+};
 
 export const getPartytownScript = () =>
   `<script src="${partytownLibUrl('partytown.js?v=' + VERSION)}"></script>`;

--- a/src/lib/web-worker/worker-exec.ts
+++ b/src/lib/web-worker/worker-exec.ts
@@ -213,14 +213,7 @@ export const insertIframe = (winId: WinId, iframe: WorkerInstance) => {
   callback();
 };
 
-export const resolveToUrl = (
-  env: WebWorkerEnvironment,
-  url: string,
-  type: ResolveUrlType | null,
-  baseLocation?: Location,
-  resolvedUrl?: URL,
-  configResolvedUrl?: any
-) => {
+const resolveBaseLocation = (env: WebWorkerEnvironment, baseLocation?: Location) => {
   baseLocation = env.$location$;
   while (!baseLocation.host) {
     env = environments[env.$parentWinId$];
@@ -229,7 +222,20 @@ export const resolveToUrl = (
       break;
     }
   }
+  return baseLocation;
+}
 
+export const resolveToUrl = (
+  env: WebWorkerEnvironment,
+  url: string,
+  type: ResolveUrlType | null,
+  baseLocation?: Location,
+  resolvedUrl?: URL,
+  configResolvedUrl?: any
+) => {
+  
+  baseLocation = resolveBaseLocation(env, baseLocation);
+  
   resolvedUrl = new URL(url || '', baseLocation as any);
   if (type && webWorkerCtx.$config$.resolveUrl) {
     configResolvedUrl = webWorkerCtx.$config$.resolveUrl!(resolvedUrl, baseLocation, type!);
@@ -242,6 +248,18 @@ export const resolveToUrl = (
 
 export const resolveUrl = (env: WebWorkerEnvironment, url: string, type: ResolveUrlType | null) =>
   resolveToUrl(env, url, type) + '';
+
+export const resolveSendBeaconRequestParameters = (env: WebWorkerEnvironment, url: string) => {
+  const baseLocation = resolveBaseLocation(env);
+  const resolvedUrl = new URL(url || '', baseLocation as any);
+  if (webWorkerCtx.$config$.resolveSendBeaconRequestParameters) {
+    const configResolvedParams = webWorkerCtx.$config$.resolveSendBeaconRequestParameters!(resolvedUrl, baseLocation);
+    if (configResolvedParams) {
+      return configResolvedParams;
+    }
+  }
+  return {};
+}
 
 export const getPartytownScript = () =>
   `<script src="${partytownLibUrl('partytown.js?v=' + VERSION)}"></script>`;

--- a/src/lib/web-worker/worker-navigator.ts
+++ b/src/lib/web-worker/worker-navigator.ts
@@ -1,7 +1,7 @@
 import type { WebWorkerEnvironment } from '../types';
 import { debug } from '../utils';
 import { logWorker } from '../log';
-import { resolveUrl } from './worker-exec';
+import { resolveSendBeaconRequestParameters, resolveUrl } from './worker-exec';
 import { webWorkerCtx } from './worker-constants';
 import { getter } from './worker-proxy';
 
@@ -25,6 +25,7 @@ export const createNavigator = (env: WebWorkerEnvironment) => {
           body,
           mode: 'no-cors',
           keepalive: true,
+          ...(resolveSendBeaconRequestParameters(env, url))
         });
         return true;
       } catch (e) {

--- a/src/lib/web-worker/worker-navigator.ts
+++ b/src/lib/web-worker/worker-navigator.ts
@@ -13,7 +13,7 @@ export const createNavigator = (env: WebWorkerEnvironment) => {
           logWorker(
             `sendBeacon: ${resolveUrl(env, url, null)}${
               body ? ', data: ' + JSON.stringify(body) : ''
-            }`
+            }, resolvedParams: ${JSON.stringify(resolveSendBeaconRequestParameters(env, url))}`
           );
         } catch (e) {
           console.error(e);

--- a/src/lib/web-worker/worker-navigator.ts
+++ b/src/lib/web-worker/worker-navigator.ts
@@ -25,7 +25,7 @@ export const createNavigator = (env: WebWorkerEnvironment) => {
           body,
           mode: 'no-cors',
           keepalive: true,
-          ...(resolveSendBeaconRequestParameters(env, url))
+          ...resolveSendBeaconRequestParameters(env, url),
         });
         return true;
       } catch (e) {

--- a/tests/platform/navigator/index.html
+++ b/tests/platform/navigator/index.html
@@ -50,6 +50,18 @@
         logSetters: true,
         logStackTraces: false,
         logScriptExecution: true,
+        resolveSendBeaconRequestParameters: (url, location) => {
+          if (url.searchParams.has('withParams')) {
+            return {
+              keepalive: false,
+              mode: 'same-origin',
+              cache: 'no-cache',
+              headers: new Headers({
+                'custom-header': 'custom-value'
+              })
+            };
+          }
+        }
       };
     </script>
     <script src="/~partytown/debug/partytown.js"></script>
@@ -80,6 +92,20 @@
             const success = navigator.sendBeacon('api.js', formData);
             elm.textContent = success;
             elm.className = 'testSendBeacon';
+          })();
+        </script>
+      </li>
+      <li>
+        <strong>sendBeacon() resolveParams</strong>
+        <code id="testSendBeaconResolveParams"></code>
+        <script type="text/partytown">
+          (function () {
+            const elm = document.getElementById('testSendBeaconResolveParams');
+            const formData = new FormData();
+            formData.append('name', 'value');
+            const success = navigator.sendBeacon('api.js?withParams=1', formData);
+            elm.textContent = success;
+            elm.className = 'testSendBeaconResolveParams';
           })();
         </script>
       </li>

--- a/tests/platform/navigator/navigator.spec.ts
+++ b/tests/platform/navigator/navigator.spec.ts
@@ -1,6 +1,14 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, Request } from '@playwright/test';
 
 test('navigator', async ({ page }) => {
+  const sendBeaconWithParamsRequest = new Promise<Request>((resolve) => {
+    page.on('request', (request) => {
+      if (request.url().includes('api.js?withParams=1')) {
+        resolve(request);
+      }
+    });
+  });
+
   await page.goto('/tests/platform/navigator/');
 
   const testUserAgent = await page.waitForSelector('.testUserAgent');
@@ -10,6 +18,16 @@ test('navigator', async ({ page }) => {
   await page.waitForSelector('.testSendBeacon');
   const testSendBeacon = page.locator('#testSendBeacon');
   await expect(testSendBeacon).toContainText('true');
+
+  await page.waitForSelector('.testSendBeaconResolveParams');
+  const testSendBeaconResolveParams = page.locator('#testSendBeaconResolveParams');
+  await expect(testSendBeaconResolveParams).toContainText('true');
+  const beaconWithParamsRequest = await sendBeaconWithParamsRequest;
+  const headers = await beaconWithParamsRequest.allHeaders();
+  expect(headers['cache-control']).toBe('max-age=0');
+  expect(headers['custom-header']).toBe('custom-value');
+  expect(headers['sec-fetch-mode']).toBe('same-origin');
+  expect(headers['sec-fetch-site']).toBe('same-origin');
 
   await page.waitForSelector('.testNavKey');
   const testNavKey = page.locator('#testNavKey');


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

This change introduces a new hook called `resolveSendBeaconRequestParameters` on the `PartytownConfig`. This enables consumers to modify a subset of the `RequestInit ` parameters being used by the fetch request that polyfills the navigator.sendBeacon API in the worker context, e.g. setting keepalive: false.

## Alternative solution

An alternative solution would be to just set `keepalive: false` as default. But as I am not aware of the reasoning behind your defaults, I thought it's a good idea to make it user configurable.

# Use cases and why

The current implementation of the `sendBeacon` has static values for the `RequestInit` parameters it uses to initialize the post request. The goal is to make those parameters being user configurable. 
I am not 100% sure why you have chosen to go with those default values, but I've notice that espcially `keepalive: true` is causing troubles in combination with google analytics (analytics.js).

I've already pointed out the behavior it causes in this issue https://github.com/BuilderIO/partytown/issues/492, but at that point I didn't know the root cause is `keepalive: true`.

Short description of what happens with some visuals.

The application starts behaving normal, the first couple of requests sent via `sendBeacon` are actually fine and not producing any errors. Until a certain amount of events was sent, most of the following requests are simply in `pending` state forever.

![image](https://github.com/BuilderIO/partytown/assets/4904455/c6874607-f766-4887-9be8-f6f640130542)

The "failing" requests are also producing errors like crazy

![image](https://github.com/BuilderIO/partytown/assets/4904455/95df4e42-44e1-488c-8399-9169b7eac7c1)

Lastly, I've figured out that also the "good" requests are having issues, as they seem to actually never finish until they run into some timeout.

![image](https://github.com/BuilderIO/partytown/assets/4904455/4ee605c9-1308-4be6-b030-70bfbdd238a9)

After manually setting `keepalive: false` and override the script locally, the application suddenly recovers and all consequent requests are perfectly fine. It looks like the never finishing requests are filling some queue which causes consequent requests to be stalled.

![image](https://github.com/BuilderIO/partytown/assets/4904455/5167508d-414a-4303-a031-99efb0a5ab97)



# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
