### PR TITLE
Allow `withCredentials` for XHR, closes #556

### DIFF
--- a/scripts/server.cjs
+++ b/scripts/server.cjs
@@ -12,6 +12,17 @@ exports.createServer = function (port, enableAtomics) {
     if (url.pathname === '/') {
       res.writeHead(301, { Location: '/tests/' });
       return res.end();
+    } else if (url.pathname === '/api/cookie') {
+      const name = url.searchParams.get('name');
+      let date = new Date();
+      date.setTime(date.getTime() + 24 * 60 * 60 * 1000); // 24 hours from now
+      let expires = date.toUTCString();
+      res.writeHead(200, {
+        'Set-Cookie': `${name}=1; Path=/; Domain=localhost; expires=${expires}; SameSite=Lax;`,
+        'Access-Control-Allow-Origin': req.headers.origin ? req.headers.origin : '*',
+        'Access-Control-Allow-Credentials': 'true',
+      });
+      return res.end();
     } else if (url.pathname.endsWith('post')) {
       res.writeHead(200);
       let body = '';

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -449,6 +449,11 @@ export interface PartytownConfig {
   set?: SetHook;
   apply?: ApplyHook;
   /**
+   * When set to true, the Partytown Web Worker will respect the `withCredentials` option of XMLHttpRequests.
+   * Default: false
+   */
+  allowXhrCredentials?: boolean;
+  /**
    * An absolute path to the root directory which Partytown library files
    * can be found. The library path must start and end with a `/`.
    * By default the files will load from the server's `/~partytown/` directory.

--- a/src/lib/web-worker/worker-window.ts
+++ b/src/lib/web-worker/worker-window.ts
@@ -587,7 +587,11 @@ export const createWindow = (
               args[1] = resolveUrl(env, args[1], 'xhr');
               (super.open as any)(...args);
             }
-            set withCredentials(_: any) {}
+            set withCredentials(_: boolean) {
+              if (webWorkerCtx.$config$.allowXhrCredentials) {
+                super.withCredentials = _;
+              }
+            }
             toString() {
               return str;
             }

--- a/tests/platform/fetch/fetch.spec.ts
+++ b/tests/platform/fetch/fetch.spec.ts
@@ -13,6 +13,10 @@ test('fetch', async ({ page }) => {
   const testFetchJson = page.locator('#testFetchJson');
   await expect(testFetchJson).toHaveText('{"mph":88}');
 
+  await page.waitForSelector('.testFetchCookie');
+  const testFetchCookie = page.locator('#testFetchCookie');
+  await expect(testFetchCookie).toContainText('server-test-fetch=1');
+
   await page.waitForSelector('.testXMLHttpRequest');
   const testXMLHttpRequest = page.locator('#testXMLHttpRequest');
   await expect(testXMLHttpRequest).toHaveText('text');
@@ -22,4 +26,8 @@ test('fetch', async ({ page }) => {
 
   const testXMLHttpRequestCstrNative = page.locator('#testXMLHttpRequestCstrNative');
   await expect(testXMLHttpRequestCstrNative).toHaveText('true');
+
+  await page.waitForSelector('.testXMLHttpRequestCookie');
+  const testXMLHttpRequestCookie = page.locator('#testXMLHttpRequestCookie');
+  await expect(testXMLHttpRequestCookie).toContainText('server-test-xhr=1');
 });

--- a/tests/platform/fetch/index.html
+++ b/tests/platform/fetch/index.html
@@ -92,6 +92,24 @@
       </li>
 
       <li>
+        <strong>fetch Set-Cookie</strong>
+        <code>
+          <span id="testFetchCookie"></span>
+        </code>
+        <script type="text/partytown">
+          (async function () {
+            const url = new URL('/api/cookie?name=server-test-fetch', location.origin);
+            const elm = document.getElementById('testFetchCookie');
+            const rsp = await fetch(url, {
+              credentials: 'include',
+            });
+            elm.textContent = document.cookie;
+            elm.className = 'testFetchCookie';
+          })();
+        </script>
+      </li>
+
+      <li>
         <strong>XMLHttpRequest</strong>
         <code id="testXMLHttpRequest"></code>
         <script type="text/partytown">
@@ -157,6 +175,27 @@
             };
 
             elm.textContent = !invalidXMLHttpRequest();
+          })();
+        </script>
+      </li>
+
+      <li>
+        <strong>XMLHttpRequest Set-Cookie</strong>
+        <code>
+          <span id="testXMLHttpRequestCookie"></span>
+        </code>
+        <script type="text/partytown">
+          (async function () {
+            const url = new URL('/api/cookie?name=server-test-xhr', location.origin);
+            const elm = document.getElementById('testXMLHttpRequestCookie');
+            const xhr = new XMLHttpRequest();
+            xhr.addEventListener('load', function () {
+              elm.textContent = document.cookie;
+              elm.className = 'testXMLHttpRequestCookie';
+            });
+            xhr.open('GET', url);
+            xhr.withCredentials = true;
+            xhr.send();
           })();
         </script>
       </li>


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [x] Bug?
- [ ] Docs / tests

# Description

Partytown currently doesn't allow the `withCredentials` option for XHR, which makes it impossible to set first party cookies from subdomains. This feature / fix would allow using Partytown with a Tagging Server.

Since I don't know the initial motivation to disable the feature, I've added a configuration to opt into allowing `withCredentials`. I would add documentation in case this is the preferred solution. Otherwise we could also just not block `withCredentials` in any case.

# Use cases and why

- The ability to use a Tagging Server with Partytown

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality

# Test Comment:

I struggled to write a test for this use-case. I've tried extensively to set first-party cookies through a subdomain on localhost, but due to cookie and localhost restrictions, I'm not sure it's possible.

The added test checks for cookies set through XHR and fetch with the `Set-Cookie` header, but this easily gets passed because they are not cross-domain.

In case anyone has an idea how to tackle this specific test case without leaving the scope of the repository, I'd be very happy to discuss details.