### PR TITLE
docs(SvelteKit): fix Google Tag Manager example

### DIFF
--- a/docs/sveltekit.md
+++ b/docs/sveltekit.md
@@ -50,7 +50,11 @@ Adapting from [the HTML integration guide](https://partytown.builder.io/html)
 
 ## 3. Then add 3rd party scripts
 
-This is where we use partytown to add those scripts (note `type="text/partytown"` below). This example shows Google Tag Manager. Putting it together with the previous changes, our `+layout.svelte` looks like:
+This is where we use partytown to add those scripts (note `type="text/partytown"` below). If your script declares global functions or variables, make sure they are explicitly declared with `window` and forwarded to the web worker.
+
+This example shows Google Tag Manager. Note `window.gtag = function()` instead of `function gtag()`.
+
+Putting it together with the previous changes, our `+layout.svelte` looks like:
 
 ```svelte
 // src/routes/+layout.svelte
@@ -65,7 +69,7 @@ This is where we use partytown to add those scripts (note `type="text/partytown"
 	<script>
 		// Forward the necessary functions to the web worker layer
 		partytown = {
-			forward: ['dataLayer.push']
+			forward: ['dataLayer.push', 'gtag']
 		};
 	</script>
 
@@ -74,7 +78,7 @@ This is where we use partytown to add those scripts (note `type="text/partytown"
 	<script type="text/partytown" src="https://www.googletagmanager.com/gtag/js?id=G-ZX7H2KPXNZ"></script>
 	<script type="text/partytown">
 		window.dataLayer = window.dataLayer || [];
-		function gtag(){dataLayer.push(arguments);}
+		window.gtag = function(){dataLayer.push(arguments);}
 		gtag('js', new Date());
 		gtag('config', 'G-ZX7H2KPXNZ');
 	</script>


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

The Google Tag Manager example for SvelteKit is wrong, when trying to use `gtag` it throws a `gtag is not defined` error. The reason it fails (not explicitly declaring the function as global) also applies to other scripts.

# Use cases and why

* Using Google Tag Manager correctly on SvelteKit.
* Making global functions and variables available

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
