### PR TITLE
fix: update worker-script innerHTML implementation

### DIFF
--- a/src/lib/web-worker/worker-constants.ts
+++ b/src/lib/web-worker/worker-constants.ts
@@ -60,7 +60,7 @@ export const structureChangingMethodNames = /*#__PURE__*/ commaSplit(
 
 /** setters that could change dimensions of elements */
 export const dimensionChangingSetterNames = /*#__PURE__*/ commaSplit(
-  'className,width,height,hidden,innerHTML,innerText,textContent'
+  'className,width,height,hidden,innerHTML,innerText,textContent,text'
 );
 
 /** method calls that could change dimensions of elements */

--- a/src/lib/web-worker/worker-script.ts
+++ b/src/lib/web-worker/worker-script.ts
@@ -36,6 +36,8 @@ export const patchHTMLScriptElement = (WorkerHTMLScriptElement: any, env: WebWor
       },
     },
 
+    text: innerHTMLDescriptor,
+
     textContent: innerHTMLDescriptor,
 
     type: {
@@ -59,11 +61,15 @@ export const patchHTMLScriptElement = (WorkerHTMLScriptElement: any, env: WebWor
 const innerHTMLDescriptor: PropertyDescriptor & ThisType<WorkerNode> = {
   get() {
     const type = getter(this, ['type']);
+
     if (isScriptJsType(type)) {
-      return getInstanceStateValue<string>(this, StateProp.innerHTML) || '';
-    } else {
-      return getter(this, ['innerHTML']);
+      const scriptContent = getInstanceStateValue<string>(this, StateProp.innerHTML);
+      if (scriptContent) {
+        return scriptContent;
+      }
     }
+
+    return getter(this, ['innerHTML']) || '';
   },
   set(scriptContent: string) {
     setInstanceStateValue(this, StateProp.innerHTML, scriptContent);

--- a/tests/integrations/load-scripts-on-main-thread/index.html
+++ b/tests/integrations/load-scripts-on-main-thread/index.html
@@ -16,6 +16,7 @@
         loadScriptsOnMainThread: [
           `${location.protocol}//${location.host}/tests/integrations/load-scripts-on-main-thread/test-script.js`,
           `inline-test-script`,
+          `inline-test-script-text`,
           /regex-test-script\.js/,
         ],
       };
@@ -211,6 +212,30 @@
               document.body.classList.add('inline-completed');
               `;
 
+            document.body.appendChild(script);
+          })();
+        </script>
+      </li>
+      <li>
+        <strong>Inline script with text</strong>
+        <code id="testInlineScriptText"></code>
+        <script type="text/javascript">
+          const globalVariableScriptText = 13;
+        </script>
+        <script type="text/partytown">
+          (function () {
+            const script = document.createElement('script');
+    
+            script.type = "text/javascript";
+            script.id = "inline-test-script-text";
+    
+            script.text = `
+              (function () {
+                const testEl = document.getElementById('testInlineScriptText');
+                testEl.className = 'testInlineScriptText';
+                testEl.innerHTML = globalVariableScriptText;
+              })();
+            `;
             document.body.appendChild(script);
           })();
         </script>

--- a/tests/integrations/load-scripts-on-main-thread/load-scripts-on-main-thread.spec.ts
+++ b/tests/integrations/load-scripts-on-main-thread/load-scripts-on-main-thread.spec.ts
@@ -25,6 +25,10 @@ test('integration window accessor', async ({ page }) => {
   await page.waitForSelector('.testInlineScript');
   const testInlineScript = page.locator('#testInlineScript');
   await expect(testInlineScript).toHaveText('12');
+  
+  await page.waitForSelector('.testInlineScriptText');
+  const testInlineScriptText = page.locator('#testInlineScriptText');
+  await expect(testInlineScriptText).toHaveText('13');
 });
 
 test('integration window accessor with snippet', async ({ page }) => {
@@ -52,4 +56,8 @@ test('integration window accessor with snippet', async ({ page }) => {
   await page.waitForSelector('.testInlineScript');
   const testInlineScript = page.locator('#testInlineScript');
   await expect(testInlineScript).toHaveText('12');
+  
+  await page.waitForSelector('.testInlineScriptText');
+  const testInlineScriptText = page.locator('#testInlineScriptText');
+  await expect(testInlineScriptText).toHaveText('13');
 });

--- a/tests/integrations/load-scripts-on-main-thread/snippet.html
+++ b/tests/integrations/load-scripts-on-main-thread/snippet.html
@@ -17,6 +17,7 @@
         loadScriptsOnMainThread: [
           `${location.protocol}//${location.host}/tests/integrations/load-scripts-on-main-thread/test-script.js`,
           `inline-test-script`,
+          `inline-test-script-text`,
           /regex-test-script\.js/,
         ],
       });
@@ -124,6 +125,30 @@
 
             codeElement.innerText = scriptElement.src;
           })()
+        </script>
+      </li>
+      <li>
+        <strong>Inline script with text</strong>
+        <code id="testInlineScriptText"></code>
+        <script type="text/javascript">
+          const globalVariableScriptText = 13;
+        </script>
+        <script type="text/partytown">
+          (function () {
+            const script = document.createElement('script');
+    
+            script.type = "text/javascript";
+            script.id = "inline-test-script-text";
+    
+            script.text = `
+              (function () {
+                const testEl = document.getElementById('testInlineScriptText');
+                testEl.className = 'testInlineScriptText';
+                testEl.innerHTML = globalVariableScriptText;
+              })();
+            `;
+            document.body.appendChild(script);
+          })();
         </script>
       </li>
       <li>

--- a/tests/platform/script/index.html
+++ b/tests/platform/script/index.html
@@ -244,6 +244,24 @@
       </li>
 
       <li>
+        <strong>set innerHTML, nested</strong>
+        <code some-attr="111" id="testInnerHTMLNested"></code>
+        <script type="text/partytown">
+          (function () {
+            const testEl = document.getElementById('testInnerHTMLNested');
+            const parent = document.createElement('div');
+            parent.innerHTML = '<script>console.log(42);<\/script>';
+
+            testEl.innerHTML = [
+              parent.firstChild.tagName,
+              parent.firstChild.innerHTML
+            ].join(', ');
+            testEl.className = 'testInnerHTMLNested';
+          })();
+        </script>
+      </li>
+
+      <li>
         <strong>async/defer</strong>
         <code id="testAsync"></code>
         <script src="defer-1.js" defer type="text/partytown"></script>

--- a/tests/platform/script/script.spec.ts
+++ b/tests/platform/script/script.spec.ts
@@ -41,6 +41,10 @@ test('script', async ({ page }) => {
   const testInnerHTMLError = page.locator('#testInnerHTMLError');
   await expect(testInnerHTMLError).toHaveText('gahh');
 
+  await page.waitForSelector('.testInnerHTMLNested');
+  const testInnerHTMLNested = page.locator('#testInnerHTMLNested');
+  await expect(testInnerHTMLNested).toHaveText('SCRIPT, console.log(42);');
+
   await page.waitForSelector('.testAsync');
   const testAsync = page.locator('#testAsync');
   const testAsyncText = await testAsync.innerText();


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

There are some bugs in Partytown's `<script>` implementation that were reported looong time ago along with MRs that were supposed to fix those bugs, unfortunately none was merged yet:
- https://github.com/BuilderIO/partytown/pull/234
- https://github.com/BuilderIO/partytown/pull/399

In summary:

#### 1. Partytown does not correctly handle nested `innerHTML` on `<script>` elements.
Take a look at this code:
```
div = document.createElement('div');
div.innerHTML = '<script>console.log(42);</script>';
console.log(div.firstChild.innerHTML);
```
It should log the content of the script. Unfortunately when run inside Partytown it returns empty string.

#### 2. Partytown does not properly handle code like this:
```
script = document.createElement('script');
script.text = 'console.log(42);';
```

GTM uses this internally when setting content of scripts added as custom HTML tags.

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

I use GTM through Partytown. However I want to have some custom HTML tags that are always executed on main thread.

Code for custom HTML tag looks somewhat like this:
```
 <script type="text/javascript" id="load-on-main">
  (function () {
    ... some third-party js code ...
  })()
</script>
```

I then whitelist script IDs with `loadScriptsOnMainThread`. When this is deployed, I end up with nested calls for `script.innerHTML` and `script.text`. Changes in this MR fixes the problem.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
