### PR TITLE
docs: Copy window example from SvelteKit implementation docs

### DIFF
--- a/docs/forwarding-events.md
+++ b/docs/forwarding-events.md
@@ -28,6 +28,18 @@ However, since GTM and Facebook Pixel were actually loaded in the web worker, th
 
 Notice the forward configs are just strings, not actual objects. We're using strings here so we can easily serialize what service variable was called, along with the function argument values. When the web worker receives the information, it then knows how to correctly apply the call and arguments that were fired from the main thread.
 
+If your script declares global functions or variables, make sure they are explicitly declared with `window` and forwarded to the web worker. This example shows the gtag function from Google Tag Manager. Note `window.gtag = function gtag()` instead of `function gtag()`.
+
+```html
+<script>
+    window.dataLayer = window.dataLayer || [];
+    window.gtag = function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'YOUR-ID-HERE');
+</script>
+```
+
 You can customize each forwarded variable with the following settings:
 
 - ### preserveBehavior

--- a/docs/google-tag-manager.md
+++ b/docs/google-tag-manager.md
@@ -14,7 +14,7 @@ Set the script element's `type` attribute to `text/partytown`. For example:
   <script type="text/partytown" src="https://www.googletagmanager.com/gtag/js?id=YOUR-ID-HERE"></script>
   <script type="text/partytown">
     window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
+    window.gtag = function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
 
     gtag('config', 'YOUR-ID-HERE');


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Copy information about explicitly adding functions to window from SvelteKit docs.

# Use cases and why

This is related to all frameworks

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
