### PR TITLE
Add fallback error if window.top returns undefined

### DIFF
--- a/src/lib/sandbox/main-serialization.ts
+++ b/src/lib/sandbox/main-serialization.ts
@@ -127,9 +127,9 @@ const serializeCssRuleForWorker = (cssRule: any) => {
   }
   return obj;
 };
-
+const FallbackError = (window.top as any).Error;
 const serializedValueIsError = (value: any) => {
-  return value instanceof (window.top as any).Error;
+  return value instanceof ((window.top as any)?.Error || ErrorObject);
 };
 
 export const deserializeFromWorker = (


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Fixes: #226
In some setups like Turbo window.top might no longer exist when checking if serializedValue Is Error while otherwise it is running fine.
This adds a fallback to an earlier stored Error Object so this error doesn't occur and normal analytics can proceed.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
