### PR TITLE
docs: change SvelteKit section

### DIFF
--- a/docs/sveltekit.md
+++ b/docs/sveltekit.md
@@ -24,7 +24,7 @@ const config = {
   plugins: [
     sveltekit(),
     partytownVite({
-      dest: join(__dirname, 'dist', '~partytown'),
+      dest: join(__dirname, 'static', '~partytown'),
     }),
   ],
 };


### PR DESCRIPTION
# What is it?

Fixing docs for SvelteKit. Static folder is for "any static assets that should be served as-is." 

https://kit.svelte.dev/docs/project-structure#project-files-static

- [ ] Feature / enhancement
- [ ] Bug
- [x] Docs / tests
