### PR TITLE
fix: make sure unknown is mapped to HTMLUnknownElement cstr

### DIFF
--- a/src/lib/sandbox/read-main-platform.ts
+++ b/src/lib/sandbox/read-main-platform.ts
@@ -79,7 +79,15 @@ export const readMainInterfaces = () => {
   // and create each element to get their implementation
   const elms = Object.getOwnPropertyNames(mainWindow)
     .map((interfaceName) => createElementFromConstructor(docImpl, interfaceName))
-    .filter((elm) => elm)
+    .filter((elm) => {
+      if (!elm) {
+        return false;
+      }
+      const constructorName = getConstructorName(elm);
+      return !(
+        constructorName === 'HTMLUnknownElement' && elm.nodeName.toUpperCase() !== 'UNKNOWN'
+      );
+    })
     .map((elm) => [elm]);
 
   return readImplementations(elms, []);


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

## The issue

Chrome maps correctly

![image](https://github.com/BuilderIO/partytown/assets/4904455/e573e8ee-3003-4565-939e-0d56bd51f168)

WebKit browsers map other nodeNames (in this case `DIRECTORY`) to HTMLUnknownElement

![image](https://github.com/BuilderIO/partytown/assets/4904455/297279f4-ebbe-42d4-b981-0da7664043d1)

Which results in the hardcoded `UNKNOWN` property being undefined in WebKit browsers, causing them to throw errors like a madman.

![image](https://github.com/BuilderIO/partytown/assets/4904455/ef7a9917-dcca-484b-8ad5-757bb210d5cf)

## The reason

Webkit iterates over the possible APIs in a different order. It will receive `directory` as first nodeName which results in `HTMLUnknownElement` constructor. The function `readOwnImplementation` maintains a `Set<string>` with constructor names. So the first one to occupy the space for `HTMLUnknownElement` will be `directory`.

If you filter for the possible `cstrImpls` which have the `HTMLUnknownElement` constructor name, you'll get multiple results with different orderings, depending on the browser.

**Broken ordering on webkit**

![image](https://github.com/BuilderIO/partytown/assets/4904455/90763fa7-93ca-492d-8a7f-8acdaac04f86)

**Proper ordering on chrome**

![image](https://github.com/BuilderIO/partytown/assets/4904455/6f13a47d-5dfa-4295-83f1-4ee4af245120)


## The fix

I've simply introduced a new filter that filters out all nodenames that will result in `HTMLUnknownElement`, but `UNKNOWN`. The worker will anyway fall back to `HTMLUnknownElement`, so there should be no change in functionality.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
