### PR TITLE
fix(worker-window): polyfill CSSMediaRule

### DIFF
--- a/src/lib/web-worker/worker-window.ts
+++ b/src/lib/web-worker/worker-window.ts
@@ -354,6 +354,7 @@ export const createWindow = (
         patchDocumentElementChild(win.HTMLBodyElement, env);
         patchHTMLHtmlElement(win.HTMLHtmlElement, env);
         createCSSStyleSheetConstructor(win, 'CSSStyleSheet');
+        createCSSStyleSheetConstructor(win, 'CSSMediaRule');
 
         definePrototypeNodeType(win.Comment, 8);
         definePrototypeNodeType(win.DocumentType, 10);


### PR DESCRIPTION
# What is it?

- [ ] Feature / enhancement
- [x] Bug
- [ ] Docs / tests

# Description

Include polyfill for `CSSMediaRule` (used by hubspot tracking js)

# Use cases and why
Hubspot references CSSMediaRule in their JS and it is currently failing because it doesn't exist in worker context. 
We already have the polyfill for CSSStyleSheet and CSSMediaRule has the same interface so the same polyfill should work!

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] Added new tests to cover the fix / functionality
