### PR TITLE
feat: allow to specify a scope for text/partytown scripts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '9.0'
 
 settings:
-  autoInstallPeers: false
+  autoInstallPeers: true
   excludeLinksFromLockfile: false
 
 importers:
@@ -2008,14 +2008,14 @@ snapshots:
 
   '@rollup/plugin-terser@0.4.4(rollup@3.29.4)':
     dependencies:
+      rollup: 3.29.4
       serialize-javascript: 6.0.1
       smob: 1.4.1
       terser: 5.21.0
-    optionalDependencies:
-      rollup: 3.29.4
 
   '@rushstack/node-core-library@3.61.0(@types/node@18.18.4)':
     dependencies:
+      '@types/node': 18.18.4
       colors: 1.2.5
       fs-extra: 7.0.1
       import-lazy: 4.0.0
@@ -2023,8 +2023,6 @@ snapshots:
       resolve: 1.22.8
       semver: 7.5.4
       z-schema: 5.0.5
-    optionalDependencies:
-      '@types/node': 18.18.4
 
   '@rushstack/rig-package@0.5.1':
     dependencies:
@@ -2041,7 +2039,6 @@ snapshots:
   '@samverschueren/stream-to-observable@0.3.1(rxjs@6.6.7)':
     dependencies:
       any-observable: 0.3.0(rxjs@6.6.7)
-    optionalDependencies:
       rxjs: 6.6.7
     transitivePeerDependencies:
       - zenObservable
@@ -2149,11 +2146,11 @@ snapshots:
       color-convert: 2.0.1
 
   any-observable@0.3.0(rxjs@6.6.7):
-    optionalDependencies:
+    dependencies:
       rxjs: 6.6.7
 
   any-observable@0.5.1(rxjs@6.6.7):
-    optionalDependencies:
+    dependencies:
       rxjs: 6.6.7
 
   argparse@1.0.10:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,7 @@
 lockfileVersion: '9.0'
 
 settings:
-  autoInstallPeers: true
+  autoInstallPeers: false
   excludeLinksFromLockfile: false
 
 importers:
@@ -2008,14 +2008,14 @@ snapshots:
 
   '@rollup/plugin-terser@0.4.4(rollup@3.29.4)':
     dependencies:
-      rollup: 3.29.4
       serialize-javascript: 6.0.1
       smob: 1.4.1
       terser: 5.21.0
+    optionalDependencies:
+      rollup: 3.29.4
 
   '@rushstack/node-core-library@3.61.0(@types/node@18.18.4)':
     dependencies:
-      '@types/node': 18.18.4
       colors: 1.2.5
       fs-extra: 7.0.1
       import-lazy: 4.0.0
@@ -2023,6 +2023,8 @@ snapshots:
       resolve: 1.22.8
       semver: 7.5.4
       z-schema: 5.0.5
+    optionalDependencies:
+      '@types/node': 18.18.4
 
   '@rushstack/rig-package@0.5.1':
     dependencies:
@@ -2039,6 +2041,7 @@ snapshots:
   '@samverschueren/stream-to-observable@0.3.1(rxjs@6.6.7)':
     dependencies:
       any-observable: 0.3.0(rxjs@6.6.7)
+    optionalDependencies:
       rxjs: 6.6.7
     transitivePeerDependencies:
       - zenObservable
@@ -2146,11 +2149,11 @@ snapshots:
       color-convert: 2.0.1
 
   any-observable@0.3.0(rxjs@6.6.7):
-    dependencies:
+    optionalDependencies:
       rxjs: 6.6.7
 
   any-observable@0.5.1(rxjs@6.6.7):
-    dependencies:
+    optionalDependencies:
       rxjs: 6.6.7
 
   argparse@1.0.10:

--- a/src/lib/main/snippet.ts
+++ b/src/lib/main/snippet.ts
@@ -96,7 +96,7 @@ export function snippet(
     doc.querySelector(config!.sandboxParent || 'body')!.appendChild(sandbox);
   }
 
-  function fallback(i?: number, script?: HTMLScriptElement) {
+  function fallback() {
     // no support or timeout reached
     // basically "undo" all of the text/partytown scripts
     // so they act as normal scripts
@@ -114,16 +114,19 @@ export function snippet(
       });
     }
 
-    for (i = 0; i < scripts!.length; i++) {
-      script = doc.createElement('script');
-      script.innerHTML = scripts![i].innerHTML;
-      // We don't need to set a `nonce` on sandbox script since it is loaded via
-      // the `src` attribute. However, we do need to set a `nonce` on the current
-      // script because it contains an inline script. This action ensures that the
-      // script can still be executed even when inline scripts are blocked
-      // (assuming `unsafe-inline` is disabled and `nonce-*` is used instead).
-      script.nonce = config!.nonce;
-      doc.head.appendChild(script);
+    for (let i = 0; i < scripts!.length; i++) {
+      const script = scripts![i];
+      if (script.getAttribute('ptScope') !== 'worker') {
+        const fallbackScript = doc.createElement('script');
+        fallbackScript.innerHTML = script.innerHTML;
+        // We don't need to set a `nonce` on sandbox script since it is loaded via
+        // the `src` attribute. However, we do need to set a `nonce` on the current
+        // script because it contains an inline script. This action ensures that the
+        // script can still be executed even when inline scripts are blocked
+        // (assuming `unsafe-inline` is disabled and `nonce-*` is used instead).
+        fallbackScript.nonce = config!.nonce;
+        doc.head.appendChild(fallbackScript);
+      }
     }
 
     if (sandbox) {


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [ ] Docs / tests

# Description

We have our custom "text/partytown" scripts added to the document which meant to be executed <ins>only</ins> in the worker scope. If the fallback happens, we have to check an execution scope to avoid errors, 
like `typeof WorkerGlobalScope === 'undefined'`

I suggest more elegant way of settling a scope for a script

```html
<script type="text/partytown"  ptScope="worker" src="/worker-custom-logic.js"></script>
 ```

# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

- 1. One use case
- 2. Another use case

# Checklist:

- [ ] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
