### PR TITLE
Add workaround for exporting wp.i18n to worker

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -43,7 +43,10 @@ export const isValidMemberName = (memberName: string) =>
     startsWith(memberName, 'toJSON') ||
     startsWith(memberName, 'constructor') ||
     startsWith(memberName, 'toString') ||
-    startsWith(memberName, '_')
+    (
+      startsWith(memberName, '_') &&
+      !['__', '_n', '_x', '_nx'].includes(memberName) // Workaround for exporting wp.i18n to worker.
+    )
   );
 
 export const getLastMemberName = (applyPath: ApplyPath, i?: number) => {


### PR DESCRIPTION
When attempting to make `wp.i18n` available in a Worker, Partytown throws an error when attempting to access `wp.i18n.__()` because it is blocking the serialization of any property name that begins with "`_`". This is a workaround to prevent this from happening. It seems Partytown needs to conditionally prevent serializing these underscore-prefixed members based on the object that is being serialized.