### PR TITLE
feat(debug): Debug log of forwarded events

### DIFF
--- a/.changeset/debug-log-forwarded-events.md
+++ b/.changeset/debug-log-forwarded-events.md
@@ -1,0 +1,5 @@
+---
+'@qwik.dev/partytown': patch
+---
+
+Add `logForwardedEvents` config flag to enable debug logging for forwarded events and triggers

--- a/docs/src/routes/debugging/index.mdx
+++ b/docs/src/routes/debugging/index.mdx
@@ -17,6 +17,7 @@ If you are using Chrome DevTools to see these logs, make sure that the `Verbose`
 | `logCalls`              | Log method calls                    |
 | `logGetters`            | Log getter calls                    |
 | `logSetters`            | Log setter calls                    |
+| `logForwardedEvents`    | Log forwarded event calls           |
 | `logImageRequests`      | Log Image() src requests            |
 | `logScriptExecution`    | Log script executions               |
 | `logSendBeaconRequests` | Log navigator.sendBeacon() requests |

--- a/src/integration/api.md
+++ b/src/integration/api.md
@@ -28,6 +28,7 @@ export interface PartytownConfig {
     lib?: string;
     loadScriptsOnMainThread?: (string | RegExp)[];
     logCalls?: boolean;
+    logForwardedEvents?: boolean;
     logGetters?: boolean;
     logImageRequests?: boolean;
     logMainAccess?: boolean;

--- a/src/lib/sandbox/main-forward-trigger.ts
+++ b/src/lib/sandbox/main-forward-trigger.ts
@@ -1,4 +1,5 @@
 import {
+  debug,
   emptyObjectValue,
   getOriginalBehavior,
   len,
@@ -6,10 +7,12 @@ import {
 } from '../utils';
 import { type MainWindow, type PartytownWebWorker, type WinId, WorkerMessageType } from '../types';
 import { serializeForWorker } from './main-serialization';
+import { logMain } from '../log';
 
 export const mainForwardTrigger = (worker: PartytownWebWorker, $winId$: WinId, win: MainWindow) => {
   let queuedForwardCalls = win._ptf;
-  let forwards = (win.partytown || {}).forward || [];
+  let config = win.partytown || {};
+  let forwards = config.forward || [];
   let i: number;
   let mainForwardFn: typeof win;
 
@@ -46,6 +49,9 @@ export const mainForwardTrigger = (worker: PartytownWebWorker, $winId$: WinId, w
                 if (originalFunction) {
                   returnValue = originalFunction(args);
                 }
+                if (debug && config.logForwardedEvents) {
+                  logMain(`Forward event: ${arr.join('.')}()`);
+                }
                 forwardCall(arr, args);
                 return returnValue;
               };
@@ -55,6 +61,9 @@ export const mainForwardTrigger = (worker: PartytownWebWorker, $winId$: WinId, w
 
   if (queuedForwardCalls) {
     for (i = 0; i < len(queuedForwardCalls); i += 2) {
+      if (debug && config.logForwardedEvents) {
+        logMain(`Forward queued event: ${queuedForwardCalls[i].join('.')}()`);
+      }
       forwardCall(queuedForwardCalls[i], queuedForwardCalls[i + 1]);
     }
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -501,6 +501,10 @@ export interface PartytownConfig {
    */
   logSetters?: boolean;
   /**
+   * Log forwarded events (debug mode required)
+   */
+  logForwardedEvents?: boolean;
+  /**
    * Log Image() src requests (debug mode required)
    */
   logImageRequests?: boolean;

--- a/src/lib/web-worker/worker-forwarded-trigger.ts
+++ b/src/lib/web-worker/worker-forwarded-trigger.ts
@@ -1,7 +1,8 @@
 import { deserializeFromMain } from './worker-serialization';
-import { environments } from './worker-constants';
+import { environments, webWorkerCtx } from './worker-constants';
 import type { ForwardMainTriggerData } from '../types';
-import { len } from '../utils';
+import { debug, len } from '../utils';
+import { logWorker } from '../log';
 
 export const workerForwardedTriggerHandle = ({
   $winId$,
@@ -14,11 +15,26 @@ export const workerForwardedTriggerHandle = ({
     let i = 0;
     let l = len($forward$);
 
+    if (debug && webWorkerCtx.$config$.logForwardedEvents) {
+      logWorker(`Forwarded event received: ${$forward$.join('.')}()`, $winId$);
+    }
+
     for (; i < l; i++) {
       if (i + 1 < l) {
         target = target[$forward$[i]];
       } else {
-        target[$forward$[i]].apply(target, deserializeFromMain(null, $winId$, [], $args$));
+        const deserializedArgs = deserializeFromMain(null, $winId$, [], $args$);
+        if (debug && webWorkerCtx.$config$.logForwardedEvents) {
+          logWorker(
+            `Forwarded event execute: ${$forward$.join('.')}(${deserializedArgs
+              .map((a: any) =>
+                typeof a === 'object' ? JSON.stringify(a)?.slice(0, 60) : String(a)
+              )
+              .join(', ')})`,
+            $winId$
+          );
+        }
+        target[$forward$[i]].apply(target, deserializedArgs);
       }
     }
   } catch (e) {

--- a/tests/integrations/event-forwarding/index.html
+++ b/tests/integrations/event-forwarding/index.html
@@ -19,6 +19,7 @@
         logSetters: true,
         logStackTraces: false,
         logScriptExecution: true,
+        logForwardedEvents: true,
       };
     </script>
     <script src="/~partytown/debug/partytown.js"></script>


### PR DESCRIPTION
# What is it?

- [x] Feature / enhancement
- [ ] Bug
- [x] Docs / tests

# Description

Adds a new `logForwardedEvents` config flag (debug mode required) that logs all forwarded event activity on both the main thread and web worker:
- Main: "Forward event: fn()" for live calls
- Main: "Forward queued event: fn()" for calls replayed from queue
- Worker: "Forwarded event received: fn()"
- Worker: "Forwarded event execute: fn(args...)"
# Use cases and why

<!-- Actual / expected behavior if it's a bug -->

Personally, I find such debug print useful when I was investigating a GTM data layer events timing issue under Partytown.

# Checklist:

- [x] My code follows the [developer guidelines of this project](https://github.com/BuilderIO/partytown/blob/main/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] Added new tests to cover the fix / functionality
