### PR TITLE
fix: initialise ErrorObject to Error instead of null to prevent instanceof crash

### DIFF
--- a/src/lib/sandbox/main-serialization.ts
+++ b/src/lib/sandbox/main-serialization.ts
@@ -127,7 +127,7 @@ const serializeCssRuleForWorker = (cssRule: any) => {
   }
   return obj;
 };
-let ErrorObject: any = null;
+let ErrorObject: any = Error;
 const serializedValueIsError = (value: any) => {
   ErrorObject = (window.top as any)?.Error || ErrorObject;
   return value instanceof ErrorObject;

--- a/src/lib/web-worker/worker-serialization.ts
+++ b/src/lib/web-worker/worker-serialization.ts
@@ -86,7 +86,7 @@ export const serializeForMain = (
   }
 };
 
-const supportsTrustedHTML = typeof TrustedHTML !== 'undefined';
+const supportsTrustedHTML = typeof TrustedHTML === 'function';
 
 const serializeObjectForMain = (
   winId: WinId,


### PR DESCRIPTION
Fixes #711.

## Changes

**`src/lib/sandbox/main-serialization.ts`**

Initialise `ErrorObject` to the local `Error` constructor instead of `null`. When `window.top` is cross-origin, `window.top.Error` silently returns `undefined`, and the existing `|| ErrorObject` fallback then keeps `ErrorObject` as `null` — causing `value instanceof null` to throw in Safari.

Using `Error` as the initial value means the fallback chain always produces a callable value. On the first call where `window.top.Error` is accessible it upgrades to that, preserving correct cross-realm error detection.

**`src/lib/web-worker/worker-serialization.ts`**

Simplify `supportsTrustedHTML` to `typeof TrustedHTML === 'function'`. This guards against `TrustedHTML` being defined but non-callable (observed in some WebKit builds), and subsumes the `!== 'undefined'` check which was redundant.