### PR TITLE
docs: fix homepage test pages link

### DIFF
--- a/.changeset/fix-tests-doc-link.md
+++ b/.changeset/fix-tests-doc-link.md
@@ -1,0 +1,4 @@
+---
+---
+
+docs: fix homepage test pages link

--- a/docs/src/routes/index.mdx
+++ b/docs/src/routes/index.mdx
@@ -30,7 +30,7 @@ We set out to solve this situation, so that apps of all sizes will be able to co
 
 ## Web Workers
 
-Partytown's philosophy is that the main thread should be dedicated to your code, and any scripts that are not required to be in the [critical path](https://developers.google.com/web/fundamentals/performance/critical-rendering-path) should be moved to a [web worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API). Main thread performance is, without question, more important than web worker thread performance. Please see the [test pages](/tests/) for some live demos.
+Partytown's philosophy is that the main thread should be dedicated to your code, and any scripts that are not required to be in the [critical path](https://developers.google.com/web/fundamentals/performance/critical-rendering-path) should be moved to a [web worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API). Main thread performance is, without question, more important than web worker thread performance. Please see the [test pages in the repository](https://github.com/QwikDev/partytown/tree/main/tests) for examples you can run locally.
 
 ![Without Partytown and With Partytown: Your code and third-party code compete for main thread resources](https://user-images.githubusercontent.com/452425/152363590-89d3b9a5-35c7-4c12-8f3e-c8b5ce4bb267.png)
 


### PR DESCRIPTION
Summary
- Fixes the homepage link reported in #716 by replacing the broken `/tests/` docs link with the repository's `tests` directory.
- Updates the sentence so it no longer describes the removed public route as live demos.
- Adds an empty changeset for the docs-only change.

Validation
- `curl.exe -L -I https://partytown.qwik.dev/tests/` returned `404 Not Found`, confirming the reported broken route.
- `curl.exe -L -I https://github.com/QwikDev/partytown/tree/main/tests` returned `200 OK`.
- `Select-String -Path docs\src\routes\index.mdx -Pattern '\](/tests/)'` returned no matches.
- `git diff --check` passed with line-ending warnings only from the Windows checkout.
- `git diff --cached --check` passed before commit.
- `npx --yes prettier@3.6.2 --check .changeset/fix-tests-doc-link.md` passed.

Notes
- Fixes #716.
- No runtime behavior changes.
- Full docs build was not run locally because this checkout was narrowed with sparse checkout after repeated GitHub HTTPS clone interruptions; the change is limited to one docs link and its changeset.
- `npx --yes prettier@3.6.2 --check docs/src/routes/index.mdx .changeset/fix-tests-doc-link.md` would reformat pre-existing HTML anchor wrapping in the page, so I kept the diff limited to the broken link fix.